### PR TITLE
Deserialization of YAML into composite types

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -13,7 +13,7 @@ module YAML
     include("parser.jl")
     include("composer.jl")
     include("constructor.jl")
-
+    include("deserialization.jl")
 
     function load(ts::TokenStream)
         events = EventStream(ts)

--- a/src/deserialization.jl
+++ b/src/deserialization.jl
@@ -1,0 +1,45 @@
+# Deserialize a YAML string to a given type.
+#
+# Example:
+# ```
+# using Base.Test
+#
+# type Foo
+#    bar::UTF8String
+# end
+#
+# @test deserialize(Foo, """{"bar": "baz"}""") == Foo("baz")
+# ```
+#
+# Nullable fields are considered optional, but all other fields are mandatory.
+#
+deserialize{T}(::Type{T}, yaml::AbstractString) = deserialize(T, YAML.load(yaml))
+deserialize{T}(::Type{T}, yaml::Dict) =
+    T([deserialize_field(T, f, yaml) for f in fieldnames(T)]...)
+function deserialize{T}(::Type{Array{T,1}}, a::Array{Any,1})
+    result = Array{T, 1}()
+    for e in a
+        element_value = deserialize(T, e)
+        push!(result, element_value)
+    end
+    result
+end
+deserialize{T<:Integer}(::Type{T}, i::Integer) = T(i)
+deserialize{T<:Integer}(::Type{T}, i::AbstractString) = parse(T, i)
+deserialize{T<:AbstractFloat}(::Type{T}, i::AbstractFloat) = T(i)
+deserialize{T<:AbstractFloat}(::Type{T}, i::AbstractString) = parse(T, i)
+deserialize{T<:AbstractString}(::Type{T}, i::AbstractString) = T(i)
+deserialize{T}(::Type{Nullable{T}}, yaml::AbstractString) = deserialize(T, yaml)
+deserialize{T}(::Type{Nullable{T}}, yaml::Dict) = deserialize(T, yaml)
+deserialize{T}(::Type{Nullable{T}}, ::Void) = Nullable{T}()
+deserialize{T}(::Type{Nullable{T}}, x) = deserialize(T, x)
+
+# Deserialize a given field (name or symbol) from a Dict, into a given type.
+deserialize_field{Tf}(::Type{Tf}, field::AbstractString, yaml::Dict) = deserialize(Tf, yaml[field])
+deserialize_field{Tf<:Nullable}(::Type{Tf}, field::AbstractString, yaml::Dict) =
+    haskey(yaml, field) ? deserialize(Tf, yaml[field]) : Tf()
+deserialize_field{Tf}(ta::Type{Array{Tf}}, field::AbstractString, yaml::Dict) =
+    deserialize(ta, yaml[field])
+
+deserialize_field{T}(::Type{T}, field::Symbol, yaml::Dict) =
+    deserialize_field(fieldtype(T,field), string(field), yaml)

--- a/test/deserialization_test.jl
+++ b/test/deserialization_test.jl
@@ -1,0 +1,75 @@
+using Base.Test
+
+import Base.==
+
+#
+# Test deseerialization into primitive fields, and test optional fields
+#
+
+immutable NameHrAvg
+    name::AbstractString
+    hr::Nullable{Int}
+    avg::Float64
+end
+
+==(a::NameHrAvg, b::NameHrAvg) = a.name == b.name && a.avg == b.avg &&
+    (isnull(a.hr) && isnull(b.hr) || !isnull(a.hr) && !isnull(b.hr) && get(a.hr) == get(b.hr))
+
+#
+# Test deserialization of array fields
+#
+immutable Teams
+    american::Vector{AbstractString}
+    national::Vector{AbstractString}
+end
+global Teams
+
+==(a::Teams, b::Teams) = a.american == b.american && a.national == b.national
+
+#
+# Test deserialization of composite fields
+#
+
+immutable CompositeTeams
+    teams::Teams
+end
+
+==(a::CompositeTeams, b::CompositeTeams) = a.teams == b.teams
+
+#
+# Test all listed files
+#
+
+deserialization_tests = [
+    ("deserialize-01", NameHrAvg("Mark McGwire", Nullable{Int}(65), 0.278)),
+
+    ("deserialize-02",
+        Teams(ASCIIString["Boston Red Sox", "Detroit Tigers", "New York Yankees"],
+              ASCIIString["New York Mets", "Chicago Cubs", "Atlanta Braves"])),
+
+    ("deserialize-03", NameHrAvg("Mark McGwire", Nullable{Int}(), 0.278)),
+
+    ("deserialize-04",
+        CompositeTeams(Teams(ASCIIString["Boston Red Sox", "Detroit Tigers", "New York Yankees"],
+                             ASCIIString["New York Mets", "Chicago Cubs", "Atlanta Braves"])))
+]
+
+for test in deserialization_tests
+    filename = test[1]
+    expected = test[2]
+
+    @printf("%s: ", filename)
+
+    datatype = typeof(expected)
+    data = YAML.load_file(joinpath(testdir, string(filename, ".data")))
+    actual = YAML.deserialize(datatype, data)
+
+    if actual == expected
+        @printf("PASSED\n")
+    else
+        @printf("FAILED\n")
+        @printf("Expected:\n%s\nParsed:\n%s\n",
+                expected, actual)
+    end
+end
+

--- a/test/deserialize-01.data
+++ b/test/deserialize-01.data
@@ -1,0 +1,3 @@
+name: Mark McGwire
+hr:   65
+avg:  0.278

--- a/test/deserialize-02.data
+++ b/test/deserialize-02.data
@@ -1,0 +1,8 @@
+american:
+  - Boston Red Sox
+  - Detroit Tigers
+  - New York Yankees
+national:
+  - New York Mets
+  - Chicago Cubs
+  - Atlanta Braves

--- a/test/deserialize-03.data
+++ b/test/deserialize-03.data
@@ -1,0 +1,2 @@
+name: Mark McGwire
+avg:  0.278

--- a/test/deserialize-04.data
+++ b/test/deserialize-04.data
@@ -1,0 +1,9 @@
+teams:
+    american:
+      - Boston Red Sox
+      - Detroit Tigers
+      - New York Yankees
+    national:
+      - New York Mets
+      - Chicago Cubs
+      - Atlanta Braves

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,3 +86,5 @@ for test in tests
         @printf("%s: PASSED\n", test)
     end
 end
+
+include("deserialization_test.jl")


### PR DESCRIPTION
This adds a feature to deserialize YAML into composite Julia types. For instance, one can deserialize the yaml in `data` directly into a user defined type:

```
import YAML

data = """
name: Mark McGwire
hr:   65
avg:  0.278
"""

immutable NameHrAvg
  name::AbstractString
  hr::Int
  avg::Float64
end

yaml = YAML.load(data)
x = YAML.deserialize(NameHrAvg, yaml)
println(x)
```

prints

```
NameHrAvg("Mark McGwire",65,0.278)
```

Originally written by @tlycken for JSON, adapted by me for YAML.
