### PR TITLE
Provocation: Use multiple dispatch instead of typeof checks. 

### DIFF
--- a/src/composer.jl
+++ b/src/composer.jl
@@ -80,16 +80,11 @@ function compose_node(composer::Composer, parent::Union{Node, Void},
         end
     end
 
-    node = nothing
-    if typeof(event) == ScalarEvent
-        node = compose_scalar_node(composer, anchor)
-    elseif typeof(event) == SequenceStartEvent
-        node = compose_sequence_node(composer, anchor)
-    elseif typeof(event) == MappingStartEvent
-        node = compose_mapping_node(composer, anchor)
-    end
-
-    node
+    compose_event!(event::ScalarEvent) = compose_scalar_node(composer, anchor)
+    compose_event!(event::SequenceStartEvent) = compose_sequence_node(composer, anchor)
+    compose_event!(event::MappingStartEvent) = compose_mapping_node(composer, anchor)
+    compose_event!(event::Any) = nothing
+    compose_event!(event)
 end
 
 

--- a/src/composer.jl
+++ b/src/composer.jl
@@ -36,11 +36,14 @@ function compose(events)
     composer = Composer(events, Dict{AbstractString, Node}(), Resolver())
     @assert typeof(forward!(composer.input)) == StreamStartEvent
     node = compose_document(composer)
-    if typeof(peek(composer.input)) == StreamEndEvent
-        forward!(composer.input)
-    else
-        @assert typeof(peek(composer.input)) == DocumentStartEvent
+
+    function compose!(input)
+        peeked_value = peek(input)
+        c!!(::StreamEndEvent) = forward!(input)
+        c!!(::Any) = @assert typeof(peek(input)) == DocumentStartEvent
+        c!!(peeked_value)
     end
+    compose!(composer.input)
     node
 end
 

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -73,12 +73,12 @@ function construct_object(constructor::Constructor, node::Node; deep=false)
 
         if haskey(constructor.yaml_constructors, nothing)
             node_constructor = constructor.yaml_constructors[nothing]
-        elseif typeof(node) == ScalarNode
-            node_constructor = construct_scalar
-        elseif typeof(node) == SequenceNode
-            node_constructor = construct_sequence
-        elseif typeof(node) == MappingNode
-            node_constructor = construct_mapping
+        else
+            construct!(node::ScalarNode) = construct_scalar
+            construct!(node::SequenceNode) = construct_sequence
+            construct!(node::MappingNode) = construct_mapping
+            construct!(node::Any) = nothing
+            node_constructor = construct!(node)
         end
     end
 

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -101,23 +101,21 @@ end
 
 
 function construct_scalar(constructor::Constructor, node::Node)
-    if typeof(node) != ScalarNode
-        throw(ConstructorError(nothing, nothing,
+    construct!(node::ScalarNode) = node.value
+    construct!(node::Any) = throw(ConstructorError(nothing, nothing,
                                "expected a scalar node, but found $(typeof(node))",
                                node.start_mark))
-    end
-    node.value
+    return construct!(node)
 end
 
 
 function construct_sequence(constructor::Constructor, node::Node; deep=false)
-    if typeof(node) != SequenceNode
+    construct!(node::SequenceNode) = [construct_object(constructor, child, deep=deep) for child in node.value]
+    construct!(node::Any) = 
         throw(ConstructorError(nothing, nothing,
                                "expected a sequence node, but found $(typeof(node))",
                                node.start_mark))
-    end
-
-    [construct_object(constructor, child, deep=deep) for child in node.value]
+    construct!(node)
 end
 
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -426,13 +426,19 @@ function parse_block_mapping_key(stream::EventStream)
     token = peek(stream.input)
     if typeof(token) == KeyToken
         forward!(stream.input)
-        if !in(typeof(peek(stream.input)), [KeyToken, ValueToken, BlockEndToken])
-            push!(stream.states, parse_block_mapping_value)
-            return parse_block_node_or_indentless_sequence(stream)
-        else
+        peeked_value = peek(stream.input)
+
+        function parse!(token::Union{KeyToken, ValueToken, BlockEndToken})
             stream.state = parse_block_mapping_value
             return process_empty_scalar(stream, token.span.end_mark)
         end
+
+        function parse!(token::Any)
+            push!(stream.states, parse_block_mapping_value)
+            return parse_block_node_or_indentless_sequence(stream)
+        end
+
+        return parse!(peeked_value)
     end
 
     if typeof(token) != BlockEndToken

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -450,7 +450,8 @@ end
 
 function parse_block_mapping_value(stream::EventStream)
     token = peek(stream.input)
-    if typeof(token) == ValueToken
+
+    function parse!(token::ValueToken)
         forward!(stream.input)
         if !in(typeof(peek(stream.input)), [KeyToken, ValueToken, BlockEndToken])
             push!(stream.states, parse_block_mapping_key)
@@ -459,10 +460,12 @@ function parse_block_mapping_value(stream::EventStream)
             stream.state = parse_block_mapping_key
             process_empty_scalar(stream, token.span.end_mark)
         end
-    else
+    end
+    function parse!(token::Any)
         stream.state = parse_block_mapping_key
         process_empty_scalar(stream, token.span.start_mark)
     end
+    parse!(token)
 end
 
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -375,13 +375,18 @@ function parse_block_sequence_entry(stream::EventStream)
     token = peek(stream.input)
     if typeof(token) == BlockEntryToken
         forward!(stream.input)
-        if !in(typeof(peek(stream.input)), [BlockEntryToken, BlockEndToken])
-            push!(stream.states, parse_block_sequence_entry)
-            return parse_block_node(stream)
-        else
+        peeked_value = peek(stream.input)
+
+        function parse!(token::Union{BlockEntryToken, BlockEndToken})
             stream.state = parse_block_sequence_entry
             return process_empty_scalar(stream, token.span.end_mark)
         end
+
+        function parse!(token::Any)
+            push!(stream.states, parse_block_sequence_entry)
+            return parse_block_node(stream)
+        end
+        return parse!(peeked_value)
     end
 
     if typeof(token) != BlockEndToken

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -160,7 +160,8 @@ function parse_document_start(stream::EventStream)
 
     # Parse explicit document.
     token = peek(stream.input)
-    if typeof(token) != StreamEndToken
+
+    function parse_start!(token::Any) 
         start_mark = token.span.start_mark
         version, tags = process_directives(stream)
         if typeof(peek(stream.input)) != DocumentStartToken
@@ -173,7 +174,9 @@ function parse_document_start(stream::EventStream)
         push!(stream.states, parse_document_end)
         stream.state = parse_document_content
         event
-    else
+    end
+
+    function parse_start!(token::StreamEndToken)
         # Parse the end of the stream
         token = forward!(stream.input)
         event = StreamEndEvent(token.span.start_mark, token.span.end_mark)
@@ -182,6 +185,8 @@ function parse_document_start(stream::EventStream)
         stream.state = nothing
         event
     end
+
+    parse_start!(token)
 end
 
 


### PR DESCRIPTION
Howdy! I love this code, and figured I'd take some time to get familiar with it and see if I could do any fun refactorings.

From my python experience, I'm loathe to include `typeof` checks in my code, and I have a strong belief that multiple dispatch, for the most part, gives us a way to avoid most of that style of programming. 

I feel that the strategy I've employed also makes many of the weird typeof-in-a-set call patterns in the code more readable by changing them to multiple dispatch against a union type. 

The main reason to make this PR isn't so much to add the code to YAML.jl (I'm loathe to have to maintain or be responsible for code that Real Serious People need on a daily basis.) but rather to get some feedback. Is this kind of use of multiple dispatch any good? I feel it basically gives us pattern matching semantics, and that seems *extremely good* to me. 

What are y'alls feelings about this?