### PR TITLE
i) write instances of AbstractDict instead of Dict; ii) YAML.yaml returns a String.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [targets]
-test = ["Test"]
+test = ["Test", "OrderedCollections"]

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -31,8 +31,15 @@ function write(data::Any, prefix::AbstractString="")
     return String(take!(io))
 end
 
+"""
+    yaml(data)
+
+Return a YAML-formatted string of the `data`.
+"""
+yaml(data::Any) = write(data)
+
 # recursively print a dictionary
-_print(io::IO, dict::Dict, level::Int=0, ignore_level::Bool=false) =
+_print(io::IO, dict::AbstractDict, level::Int=0, ignore_level::Bool=false) =
     for (i, pair) in enumerate(dict)
         _print(io, pair, level, ignore_level ? i == 1 : false) # ignore indentation of first pair
     end
@@ -59,7 +66,7 @@ function _print(io::IO, pair::Pair, level::Int=0, ignore_level::Bool=false)
         string(pair[1]) # any useful case
     end
     print(io, _indent(key * ":", level, ignore_level)) # print the key
-    if (typeof(pair[2]) <: Dict || typeof(pair[2]) <: AbstractVector)
+    if (typeof(pair[2]) <: AbstractDict || typeof(pair[2]) <: AbstractVector)
         print(io, "\n") # a line break is needed before a recursive structure
     else
         print(io, " ") # a whitespace character is needed before a single value

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,4 +146,8 @@ const testdir = dirname(@__FILE__)
     end
 end
 
+# test that an OrderedDict is written in the correct order
+using OrderedCollections
+@test strip(YAML.yaml(OrderedDict(:c => 3, :b => 2, :a => 1))) == join(["c: 3", "b: 2", "a: 1"], "\n")
+
 end  # module


### PR DESCRIPTION
These are two minor changes which are combined in a single PR because they can nicely be tested together.

# Writing AbstractDicts

This feature solves #82. As pointed out in this issue, writing instances of `AbstractDict` allows users to make use of ordered dictionaries like `OrderedCollections.OrderedDict`. Thus, the user can determine in which order the properties are written.

Note that none of the tests is broken (i.e. all test instances are written correctly) if the `Dict` requirement is dropped in favor of `AbstractDict`. Hurray! I conclude that my initial implementation of writing YAML Strings (#68) was unnecessarily picky with the `Dict` type.

# YAML.yaml

`YAML.yaml` returns a YAML-formatted String representation of a dictionary. It is implemented as a simple alias for `YAML.write`, which could have done the same thing already. The name `YAML.yaml`, however, complies with the beautiful API of JSON.jl, which has `JSON.json` return a JSON-formatted String representation of a dictionary.

This feature takes a step towards #70 without making any breaking change (only an alias is provided). Also in #29, it has been argued in favor of a `YAML.yaml` method: https://github.com/JuliaData/YAML.jl/issues/29#issuecomment-252425851