### PR TITLE
Parse arbitrary subtypes of AbstractDict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ os:
     - windows
 julia:
     - 1.0
-    - 1.4
+    - 1.3
+    - 1.5
     - nightly
 notifications:
     email: false

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ julia = "1"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 
 [targets]
-test = ["Test", "OrderedCollections"]
+test = ["Test", "OrderedCollections", "DataStructures"]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@
 [YAML](http://yaml.org/) is a flexible data serialization format that is
 designed to be easily read and written by human beings.
 
-This library parses YAML documents into native Julia types. (Dumping Julia
-objects to YAML has not yet been implemented.)
+This library parses YAML documents into native Julia types and dumps them back into YAML documents.
 
 ## Synopsis
 
@@ -65,9 +64,7 @@ It can be loaded with
 
 ```julia
 import YAML
-
-data = YAML.load(open("test.yml"))
-
+data = YAML.load_file("test.yml")
 println(data)
 ```
 
@@ -80,6 +77,23 @@ Which will show you something like this.
 Note that ints and floats are recognized, as well as timestamps which are parsed
 into CalendarTime objects. Also, anchors and references work as expected,
 without making a copy.
+
+Dictionaries are parsed into instances of `Dict{Any,Any}` by default.
+You can, however, specify a custom type in which to parse all dictionaries.
+
+```julia
+# using Symbol keys
+data = YAML.load_file("test.yml"; dicttype=Dict{Symbol,Any})
+
+# maintaining the order from the YAML file
+using OrderedCollections
+data = YAML.load_file("test.yml"; dicttype=OrderedDict{String,Any})
+
+# specifying a default value
+using DataStructures
+data = YAML.load_file("test.yml"; dicttype=()->DefaultDict{String,Any}(Missing))
+```
+
 
 ## Writing to YAML
 

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -40,8 +40,13 @@ yaml(data::Any) = write(data)
 
 # recursively print a dictionary
 _print(io::IO, dict::AbstractDict, level::Int=0, ignore_level::Bool=false) =
-    for (i, pair) in enumerate(dict)
-        _print(io, pair, level, ignore_level ? i == 1 : false) # ignore indentation of first pair
+    if length(dict) > 0
+        for (i, pair) in enumerate(dict)
+            _print(io, pair, level, ignore_level ? i == 1 : false) # ignore indentation of first pair
+        end
+    else
+        @warn "Writing an empty $(typeof(dict)), which might be parsed as nothing"
+        print(io, "\n") # https://github.com/JuliaData/YAML.jl/issues/81
     end
 
 # recursively print an array
@@ -60,8 +65,6 @@ _print(io::IO, arr::AbstractVector, level::Int=0, ignore_level::Bool=false) =
 function _print(io::IO, pair::Pair, level::Int=0, ignore_level::Bool=false)
     key = if typeof(pair[1]) == Nothing
         "null" # this is what the YAML parser interprets as 'nothing'
-    elseif typeof(pair[1]) <: Vector && VERSION < v"0.7.0"
-        string(convert(Array{Any}, pair[1]))[4:end] # v0.6 prepends the vector type -> remove it
     else
         string(pair[1]) # any useful case
     end

--- a/test/nested-dicts.data
+++ b/test/nested-dicts.data
@@ -1,0 +1,5 @@
+outer:
+  inner:
+    something_unrelated: "1"
+anything_later:
+  check_order: "sure I do!"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,13 +55,15 @@ const test_write_ignored = [
 ]
 
 
-function equivalent(xs::Dict, ys::Dict)
+function equivalent(xs::AbstractDict, ys::AbstractDict)
     if Set(collect(keys(xs))) != Set(collect(keys(ys)))
+        @info "Not equivalent" Set(collect(keys(xs))) Set(collect(keys(ys)))
         return false
     end
 
     for k in keys(xs)
         if !equivalent(xs[k], ys[k])
+            @info "Not equivalent" xs[k] ys[k]
             return false
         end
     end
@@ -72,11 +74,13 @@ end
 
 function equivalent(xs::AbstractArray, ys::AbstractArray)
     if length(xs) != length(ys)
+        @info "Not equivalent" length(xs) length(ys)
         return false
     end
 
     for (x, y) in zip(xs, ys)
         if !equivalent(x, y)
+            @info "Not equivalent" x y
             return false
         end
     end
@@ -209,5 +213,12 @@ end
     more_constructors;
     dicttype=() -> 3.0 # wrong type
 )
+
+# issue 81
+dict_content = ["key1" => [Dict("subkey1" => "subvalue1", "subkey2" => "subvalue2"), Dict()], "key2" => "value2"]
+order_one = OrderedDict(dict_content...)
+order_two = OrderedDict(dict_content[[2,1]]...) # reverse order
+@test YAML.yaml(order_one) != YAML.yaml(order_two)
+@test YAML.load(YAML.yaml(order_one)) == YAML.load(YAML.yaml(order_two))
 
 end  # module


### PR DESCRIPTION
You can now specify which subtype of `AbstractDict` you want the parser to return. This has several benefits for the users:

- a fixed key type (e.g. `String`) can be enforced: `Dict{String,Any}`
- keys can be converted while parsing: `Dict{Symbol,Any}`
- the order of the YAML document can be maintained: `OrderedDict{String,Any}`
- default values of the dict can be specified: `()->DefaultDict{String,Any}(Missing)`

These features are in line with https://github.com/JuliaData/YAML.jl/issues/70

# Usage

You specify the desired type with the new `dicttype` argument that all loading methods have gotten:

```julia
# using Symbol keys
data = YAML.load_file("test.yml"; dicttype=Dict{Symbol,Any})

# maintaining the order from the YAML file
using OrderedCollections
data = YAML.load_file("test.yml"; dicttype=OrderedDict{String,Any})

# specifying a default value
using DataStructures
data = YAML.load_file("test.yml"; dicttype=()->DefaultDict{String,Any}(Missing))
```

By default, dictionaries are still parsed into instances of `Dict{Any,Any}`. This default makes actually sense, since YAML supports other types of keys than just `String`.

# Implementation

Everything is tested with additional unit tests. I also updated the `README.md`.

The magic happens in `constructor.jl`, particularly in the methods `construct_mapping` and `custom_mapping`, the last of which defines a closure for the former.

What I also changed in `constructor.jl` is that I removed the `deep` argument from whereever it was. It has always been set to `false` and there would not have been any effect by setting it to `true` from the outside.