### PR TITLE
Escape quotation marks in strings

### DIFF
--- a/src/writer.jl
+++ b/src/writer.jl
@@ -83,7 +83,7 @@ _print(io::IO, str::AbstractString, level::Int=0, ignore_level::Bool=false) =
         indentation = repeat("  ", level + 1)
         println(io, "|\n$indentation" * replace(str, "\n"=>"\n"*indentation)) # indent each line
     else
-        println(io, "\"" * str * "\"") # be very specific about strings
+        println(io, "\"" * replace(str, "\"" => "\\\"") * "\"") # quote all strings
     end
 
 # handle NaNs and Infs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,7 +135,6 @@ function write_and_load(data::Any)
     end
 end
 
-
 const testdir = dirname(@__FILE__)
 @testset for test in tests
     data = YAML.load_file(
@@ -220,5 +219,8 @@ order_one = OrderedDict(dict_content...)
 order_two = OrderedDict(dict_content[[2,1]]...) # reverse order
 @test YAML.yaml(order_one) != YAML.yaml(order_two)
 @test YAML.load(YAML.yaml(order_one)) == YAML.load(YAML.yaml(order_two))
+
+# issue 89 - quotes in strings
+@test YAML.load(YAML.yaml(Dict("a" => """a "quoted" string""")))["a"] == """a "quoted" string"""
 
 end  # module


### PR DESCRIPTION
This PR solves issue #89 

The additional test case ensures that the written YAML is valid and that all quotes in strings are correctly escaped.