### PR TITLE
Print multiline strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "YAML"
 uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -11,9 +11,9 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "OrderedCollections", "DataStructures"]

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -88,7 +88,7 @@ _print(io::IO, str::AbstractString, level::Int=0, ignore_level::Bool=false) =
         else                       # no trailing newlines: strip
             println(io, "|-")
         end
-        indent = repeat("  ", level)
+        indent = repeat("  ", max(level, 1))
         for line in split(str, "\n")
             println(io, indent, line)
         end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -79,7 +79,22 @@ end
 
 # _print a single string
 _print(io::IO, str::AbstractString, level::Int=0, ignore_level::Bool=false) =
-    println(io, repr(MIME("text/plain"), str)) # quote and escape
+    if occursin('\n', strip(str)) || occursin('"', str)
+        if endswith(str, "\n\n")   # multiple trailing newlines: keep
+            println(io, "|+")
+            str = str[1:end-1]     # otherwise, we have one too many
+        elseif endswith(str, "\n") # one trailing newline: clip
+            println(io, "|")
+        else                       # no trailing newlines: strip
+            println(io, "|-")
+        end
+        indent = repeat("  ", level)
+        for line in split(str, "\n")
+            println(io, indent, line)
+        end
+    else
+        println(io, repr(MIME("text/plain"), str)) # quote and escape
+    end
 
 # handle NaNs and Infs
 _print(io::IO, val::Float64, level::Int=0, ignore_level::Bool=false) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,4 +224,11 @@ order_two = OrderedDict(dict_content[[2,1]]...) # reverse order
 @test YAML.load(YAML.yaml(Dict("a" => """a "quoted" string""")))["a"] == """a "quoted" string"""
 @test YAML.load(YAML.yaml(Dict("a" => """a \\"quoted\\" string""")))["a"] == """a \\"quoted\\" string"""
 
+@test YAML.load(YAML.yaml(Dict("a" => "")))["a"] == ""
+@test YAML.load(YAML.yaml(Dict("a" => "nl at end\n")))["a"] == "nl at end\n"
+@test YAML.load(YAML.yaml(Dict("a" => "one\nnl\n")))["a"] == "one\nnl\n"
+@test YAML.load(YAML.yaml(Dict("a" => "many\nnls\n\n\n")))["a"] == "many\nnls\n\n\n"
+@test YAML.load(YAML.yaml(Dict("a" => "no\ntrailing\nnls")))["a"] == "no\ntrailing\nnls"
+@test YAML.load(YAML.yaml(Dict("a" => "foo\n\"bar\\'")))["a"] == "foo\n\"bar\\'"
+
 end  # module


### PR DESCRIPTION
As discussed in #91, there are some cases where multiline strings are beneficial.
With this implementation, strings are printed on multiple lines if:

- they have newlines which are not leading or trailing
- they contain double quotes

I'm using YAML primarily for BrokenRecord.jl where we store HTTP response bodies, which are often JSON. So both cases listed above are very common, and they look much much better as a multiline string that doesn't require escaping.

This is very much open for discussion, if people prefer the simplicity of `repr` then we can, then we can stick with that. But I'd argue that  most people use YAML because it's meant to be human-readable :)