### PR TITLE
Fix Julia 1.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.0
-          - 1.3
-          - 1.5
+          - "1.0"
+          - "1.3"
+          - "1.5"
           - nightly
         os:
           - ubuntu-latest

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -1057,7 +1057,7 @@ function scan_block_scalar(stream::TokenStream, style::Char)
 
     # Chomp the tail.
     # Chomping may be Nothing or Bool.
-    if isnothing(chomping)
+    if chomping === nothing
         push!(chunks, line_break)
     elseif chomping
         push!(chunks, line_break)


### PR DESCRIPTION
The `isnothing` function isn't defined on Julia 1.0. The CI unfortunately wasn't testing against Julia 1.0 as using the number `1.0` in GitHub actions resolves to the latest version of Julia 1 (`1.0` → `1` → `1.5.3`) where as using the string `"1.0"` works as expected (`"1.0"` → `"1.0.5"`).