### PR TITLE
Unescape dollar signs in single-line strings

### DIFF
--- a/src/writer.jl
+++ b/src/writer.jl
@@ -96,7 +96,8 @@ _print(io::IO, str::AbstractString, level::Int=0, ignore_level::Bool=false) =
             println(io, indent, line)
         end
     else
-        println(io, repr(MIME("text/plain"), str)) # quote and escape
+        # quote and escape
+        println(io, replace(repr(MIME("text/plain"), str), raw"\$" => raw"$"))
     end
 
 # handle NaNs and Infs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -376,6 +376,9 @@ order_two = OrderedDict(dict_content[[2,1]]...) # reverse order
 @test YAML.load(YAML.yaml(Dict("a" => """a "quoted" string""")))["a"] == """a "quoted" string"""
 @test YAML.load(YAML.yaml(Dict("a" => """a \\"quoted\\" string""")))["a"] == """a \\"quoted\\" string"""
 
+# issue 108 - dollar signs in single-line strings
+@test YAML.yaml("foo \$ bar") == "\"foo \$ bar\"\n"
+
 @test YAML.load(YAML.yaml(Dict("a" => "")))["a"] == ""
 @test YAML.load(YAML.yaml(Dict("a" => "nl at end\n")))["a"] == "nl at end\n"
 @test YAML.load(YAML.yaml(Dict("a" => "one\nnl\n")))["a"] == "one\nnl\n"


### PR DESCRIPTION
Fixes #108 

Kind of a naive fix, but it's all we really need. Anything else would require not using `repr` at all.