### PR TITLE
Fix trailing commas in flow sequences

### DIFF
--- a/src/composer.jl
+++ b/src/composer.jl
@@ -134,8 +134,7 @@ function _compose_sequence_node(start_event::SequenceStartEvent, composer, ancho
         composer.anchors[anchor] = node
     end
 
-    while true
-        event = peek(composer.input)
+    while (event = peek(composer.input)) !== nothing
         __compose_sequence_node(event, composer, node) || break
     end
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -491,20 +491,22 @@ function _parse_flow_sequence_entry(token::Any, stream::EventStream, first_entry
             forward!(stream.input)
         else
             throw(ParserError("while parsing a flow sequence",
-                              stream.mark[end],
+                              stream.marks[end],
                               "expected ',' or ']', but got $(typeof(token))",
                               token.span.start_mark))
         end
     end
 
     token = peek(stream.input)
-    if typeof(token) == KeyToken
+    if isa(token, KeyToken)
         stream.state = parse_flow_sequence_entry_mapping_key
-        return MappingStartEvent(token.span.start_mark, token.span.end_mark,
-                                 nothing, nothing, true, true)
-    elseif typeof(token) != FlowSequenceEndToken
+        MappingStartEvent(token.span.start_mark, token.span.end_mark,
+                          nothing, nothing, true, true)
+    elseif isa(token, FlowSequenceEndToken)
+        nothing
+    else
         push!(stream.states, parse_flow_sequence_entry)
-        return parse_flow_node(stream)
+        parse_flow_node(stream)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -425,4 +425,13 @@ order_two = OrderedDict(dict_content[[2,1]]...) # reverse order
 @test YAML.load(YAML.yaml(Dict("a" => Dict()))) == Dict("a" => Dict())
 @test YAML.load(YAML.yaml(Dict("a" => []))) == Dict("a" => [])
 
+# issue 114 - gracefully handle extra commas in flow collections
+@testset "issue114" begin
+    @test YAML.load("[3,4,]") == [3,4]
+    @test YAML.load("{a:4,b:5,}") == Dict("a" => 4, "b" => 5)
+    @test YAML.load("[?a:4, ?b:5]") == [Dict("a" => 4), Dict("b" => 5)]
+    @test_throws YAML.ParserError YAML.load("[3,,4]")
+    @test_throws YAML.ParserError YAML.load("{a: 3,,b:3}")
+end
+
 end  # module


### PR DESCRIPTION
This change allows the graceful handling of trailing commas in flow sequences. I've also added a couple test cases.

It relies on `peek(composer.input)` returning `nothing` in the case of a `FlowSequenceEndToken` which is a bit hacky, but it works well enough.

Fixes #114