### PR TITLE
Improve iteration for multiple documents in one file.

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -164,8 +164,5 @@ load_file(filename::AbstractString, args...; kwargs...) =
 Parse the YAML file `filename`, and return corresponding YAML documents.
 """
 load_all_file(filename::AbstractString, args...; kwargs...) =
-    open(filename, "r") do input
-        load_all(input, args...; kwargs...)
-    end
-
+    load_all(open(filename, "r"), args...; kwargs...)
 end  # module

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -131,6 +131,9 @@ function iterate(it::YAMLDocIterator, _ = nothing)
     return doc, nothing
 end
 
+Base.IteratorSize(::Type{YAMLDocIterator}) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{YAMLDocIterator}) = Base.EltypeUnknown()
+
 """
     load_all(x::Union{AbstractString, IO}) -> YAMLDocIterator
 

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -113,10 +113,6 @@ end
 
 YAMLDocIterator(input::IO, more_constructors::_constructor=nothing, multi_constructors::Dict = Dict(); dicttype::_dicttype=Dict{Any, Any}, constructorType::Function = SafeConstructor) = YAMLDocIterator(input, constructorType(_patch_constructors(more_constructors, dicttype), multi_constructors))
 
-# It's unknown how many documents will be found. By doing this,
-# functions like `collect` do not try to query the length of the
-# iterator.
-Base.IteratorSize(::YAMLDocIterator) = Base.SizeUnknown()
 
 # Iteration protocol.
 function iterate(it::YAMLDocIterator, _ = nothing)
@@ -131,7 +127,12 @@ function iterate(it::YAMLDocIterator, _ = nothing)
     return doc, nothing
 end
 
+# It's unknown how many documents will be found. By doing this,
+# functions like `collect` do not try to query the length of the
+# iterator.
 Base.IteratorSize(::Type{YAMLDocIterator}) = Base.SizeUnknown()
+# Documents can be trees of elements or just single values, so don't promise
+# any particular type.
 Base.IteratorEltype(::Type{YAMLDocIterator}) = Base.EltypeUnknown()
 
 """

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -164,5 +164,8 @@ load_file(filename::AbstractString, args...; kwargs...) =
 Parse the YAML file `filename`, and return corresponding YAML documents.
 """
 load_all_file(filename::AbstractString, args...; kwargs...) =
-    load_all(open(filename, "r"), args...; kwargs...)
+    open(filename, "r") do f
+        io = IOBuffer(read(f))
+        load_all(io, args...; kwargs...)
+    end
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,8 +239,7 @@ const encodings = [
     @test YAML.load(IOBuffer(data)) == "test"
 end
 
-@testset "multi_doc_bom" begin
-    iterable = YAML.load_all("""
+const multidoc_contents = """
 \ufeff---\r
 test: 1
 \ufeff---
@@ -248,14 +247,50 @@ test: 2
 
 \ufeff---
 test: 3
-""")
+\ufeff---
+42
+"""
+
+@testset "multi_doc_bom" begin
+    iterable = YAML.load_all(multidoc_contents)
     (val, state) = iterate(iterable)
     @test isequal(val, Dict("test" => 1))
     (val, state) = iterate(iterable, state)
     @test isequal(val, Dict("test" => 2))
     (val, state) = iterate(iterable, state)
     @test isequal(val, Dict("test" => 3))
+    (val, state) = iterate(iterable, state)
+    @test isequal(val, 42)
     @test iterate(iterable, state) === nothing
+end
+
+@testset "multi_doc_file" begin
+    fname = tempname() # cleanup=true, file will be deleted on process exit
+    open(fname, "w") do f
+        write(f, multidoc_contents)
+    end
+    iterable = YAML.load_all_file(fname)
+    (val, state) = iterate(iterable)
+    @test isequal(val, Dict("test" => 1))
+    (val, state) = iterate(iterable, state)
+    @test isequal(val, Dict("test" => 2))
+    (val, state) = iterate(iterable, state)
+    @test isequal(val, Dict("test" => 3))
+    (val, state) = iterate(iterable, state)
+    @test isequal(val, 42)
+    @test iterate(iterable, state) === nothing
+end
+
+@testset "multi_doc_iteration_protocol" begin
+    fname = tempname() # cleanup=true, file will be deleted on process exit
+    open(fname, "w") do f
+        write(f, multidoc_contents)
+    end
+    iterable = YAML.load_all_file(fname)
+    @test Base.IteratorSize(YAML.YAMLDocIterator) == Base.SizeUnknown()
+    @test Base.IteratorEltype(YAML.YAMLDocIterator) == Base.HasEltype()
+    @test eltype(iterable) == Dict{Any, Any}
+    @test length(collect(iterable)) == 3
 end
 
 # test that an OrderedDict is written in the correct order

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -288,9 +288,8 @@ end
     end
     iterable = YAML.load_all_file(fname)
     @test Base.IteratorSize(YAML.YAMLDocIterator) == Base.SizeUnknown()
-    @test Base.IteratorEltype(YAML.YAMLDocIterator) == Base.HasEltype()
-    @test eltype(iterable) == Dict{Any, Any}
-    @test length(collect(iterable)) == 3
+    @test Base.IteratorEltype(YAML.YAMLDocIterator) == Base.EltypeUnknown()
+    @test length(collect(iterable)) == 4
 end
 
 # test that an OrderedDict is written in the correct order


### PR DESCRIPTION
The first patch implements some missing functions from the iteration interface to describe the iterator, utilities like `collect` need use some of these.

The second patch fixes `load_all_file` to not close the file before it is done reading it.

I also added a test for each of these.