### PR TITLE
Add missing arg to scalar event

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -294,7 +294,7 @@ function __parse_node(token, stream::EventStream, block, start_mark, end_mark, a
     if anchor !== nothing || tag !== nothing
         stream.state = pop!(stream.states)
         return ScalarEvent(start_mark, end_mark, anchor, tag,
-                            (implicit, false), "")
+                            (implicit, false), "", nothing)
     else
         node = block ? "block" : "flow"
         throw(ParserError("while parsing a $(node) node", start_mark,

--- a/test/empty_tag.data
+++ b/test/empty_tag.data
@@ -1,0 +1,2 @@
+thing:
+    x: !!str

--- a/test/empty_tag.expected
+++ b/test/empty_tag.expected
@@ -1,0 +1,1 @@
+Dict("thing" => Dict("x" => ""))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ const tests = [
     "multi-constructor",
     "utf-8-bom",
     "utf-32-be",
+    "empty_tag",
 ]
 
 # ignore some test cases in write_and_load testing


### PR DESCRIPTION
It appears that `ScalarEvent` requires an additional "style" argument which is not passed in the fallback method for `__parse_node`. I observed this failure when parsing a tag with an empty body, e.g. 

```yaml
thing:
    x: !MyTag
```