### PR TITLE
fix typo in accessing BlockEntryToken member

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -412,7 +412,7 @@ function parse_indentless_sequence_entry(stream::EventStream)
             return parse_block_node(stream)
         else
             stream.state = parse_indentless_sequence_entry
-            return process_empty_scalar(stream, token.end_mark)
+            return process_empty_scalar(stream, token.span.end_mark)
         end
     end
 

--- a/test/empty_list_elem.data
+++ b/test/empty_list_elem.data
@@ -1,0 +1,4 @@
+testlist:
+- 
+- one
+- two

--- a/test/empty_list_elem.expected
+++ b/test/empty_list_elem.expected
@@ -1,0 +1,1 @@
+Dict{Any,Any}("testlist" => Union{Nothing, String}[nothing, "one", "two"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ const tests = [
     "utf-8-bom",
     "utf-32-be",
     "empty_tag",
+    "empty_list_elem",
 ]
 
 # ignore some test cases in write_and_load testing


### PR DESCRIPTION
Corrected a typo in accessing the `end_mark` field from `span` of a `BlockEntryToken`. Discovered issue while parsing a specification file that resulted in:

```
julia> github_spec = YAML.load_file("api.github.com.yaml")
ERROR: type BlockEntryToken has no field end_mark
Stacktrace:
  [1] getproperty
    @ ./Base.jl:37 [inlined]
  [2] parse_indentless_sequence_entry(stream::YAML.EventStream)
    @ YAML ~/.julia/packages/YAML/U6OOW/src/parser.jl:415
  [3] peek(stream::YAML.EventStream)
    @ YAML ~/.julia/packages/YAML/U6OOW/src/parser.jl:54
  [4] _compose_sequence_node(start_event::YAML.SequenceStartEvent, composer::YAML.Composer, anchor::Nothing)
    @ YAML ~/.julia/packages/YAML/U6OOW/src/composer.jl:137
  [5] compose_sequence_node(composer::YAML.Composer, anchor::Nothing)
...
```