### PR TITLE
Remove precompile statement which is not required for Julia v1

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -1,5 +1,3 @@
-__precompile__(true)
-
 module YAML
 
 import Base: isempty, length, show, peek


### PR DESCRIPTION
Explicit `__precompile__(true)` is required for Julia v0.6, but we don't need anymore after v1.0. Our `Project.toml` says only supports Julia `"^1"`.