### PR TITLE
Fix that old `warn` is used

### DIFF
--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -245,7 +245,7 @@ function construct_yaml_int(constructor::Constructor, node::Node)
         # TODO
         #throw(ConstructorError(nothing, nothing,
             #"sexagesimal integers not yet implemented", node.start_mark))
-        warn("sexagesimal integers not yet implemented. Returning String.")
+        @warn "sexagesimal integers not yet implemented. Returning String."
         return value
     end
 
@@ -267,7 +267,7 @@ function construct_yaml_float(constructor::Constructor, node::Node)
         # TODO
         # throw(ConstructorError(nothing, nothing,
         #     "sexagesimal floats not yet implemented", node.start_mark))
-        warn("sexagesimal floats not yet implemented. Returning String.")
+        @warn "sexagesimal floats not yet implemented. Returning String."
         return value
     end
 


### PR DESCRIPTION
Replace `warn` used in Julia v0.6 to `@warn` used in Julia v1 because  v1 don't have it.