### PR TITLE
Refactoring of `src/buffered_input.jl`

### DIFF
--- a/src/buffered_input.jl
+++ b/src/buffered_input.jl
@@ -35,18 +35,20 @@ _fill(bi::BufferedInput, n::Integer) = __fill(bi, bi.input, n)
 # Peek the character in the i-th position relative to the current position.
 # (0-based)
 function peek(bi::BufferedInput, i::Integer=0)
-    if bi.avail < i + 1
-        _fill(bi, i + 1 - bi.avail)
+    i1 = i + 1
+    if bi.avail < i1
+        _fill(bi, i1 - bi.avail)
     end
-    return bi.buffer[bi.offset + i + 1]
+    return bi.buffer[bi.offset + i1]
 end
 
 
 # Return the string formed from the first n characters from the current position
 # of the stream.
 function prefix(bi::BufferedInput, n::Integer=1)
-    if bi.avail < n + 1
-        _fill(bi, n + 1 - bi.avail)
+    n1 = n + 1
+    if bi.avail < n1
+        _fill(bi, n1 - bi.avail)
     end
     return string(bi.buffer[(bi.offset + 1):(bi.offset + n)]...)
 end

--- a/src/buffered_input.jl
+++ b/src/buffered_input.jl
@@ -50,7 +50,7 @@ function prefix(bi::BufferedInput, n::Integer=1)
     if bi.avail < n1
         _fill(bi, n1 - bi.avail)
     end
-    return string(bi.buffer[(bi.offset + 1):(bi.offset + n)]...)
+    String(bi.buffer[bi.offset .+ (1:n)])
 end
 
 

--- a/src/buffered_input.jl
+++ b/src/buffered_input.jl
@@ -11,7 +11,7 @@ mutable struct BufferedInput
     avail::UInt64
 
     function BufferedInput(input::IO)
-        return new(input, Vector{Char}(undef, 0), 0, 0)
+        return new(input, Char[], 0, 0)
     end
 end
 

--- a/src/buffered_input.jl
+++ b/src/buffered_input.jl
@@ -39,7 +39,7 @@ function peek(bi::BufferedInput, i::Integer=0)
     if bi.avail < i1
         _fill(bi, i1 - bi.avail)
     end
-    return bi.buffer[bi.offset + i1]
+    bi.buffer[bi.offset + i1]
 end
 
 

--- a/src/buffered_input.jl
+++ b/src/buffered_input.jl
@@ -18,10 +18,11 @@ end
 
 # Read and buffer n more characters
 function __fill(bi::BufferedInput, bi_input::IO, n::Integer)
-    for i in 1:n
+    for _ in 1:n
         c = eof(bi_input) ? '\0' : read(bi_input, Char)
-        if bi.offset + bi.avail + 1 <= length(bi.buffer)
-            bi.buffer[bi.offset + bi.avail + 1] = c
+        i = bi.offset + bi.avail + 1
+        if i ≤ length(bi.buffer)
+            bi.buffer[i] = c
         else
             push!(bi.buffer, c)
         end


### PR DESCRIPTION
This PR includes the following improvements:

* Use `_` for a discarded value.
* Don't calculate the same value twice.
* Replace `Vector{Char}(undef, 0)` to `Char[]`.
* Remove end of function `return`s.
* Replace `string(x...)` to `String(x)` for `x::Vector{Char}`. It is approximately 9 times faster and less allocations. https://discourse.julialang.org/t/for-x-vector-char-which-should-i-use-string-x-or-join-x/115469