### PR TITLE
Format Julia source files by JuliaFormatter

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,34 @@
+# Formatting options for the default style supported in JuliaFormatter v1.0.56.
+# https://domluna.github.io/JuliaFormatter.jl/stable/
+
+# style = "default"
+# indent = 4
+# margin = 92
+always_for_in = "nothing" # default false
+# for_in_replacement = "in"
+whitespace_typedefs = true # default false
+# whitespace_ops_in_indices = false
+remove_extra_newlines = true # default false
+# import_to_using = false
+# pipe_to_function_call = false
+# short_to_long_function_def = false
+# long_to_short_function_def = false
+# always_use_return = false
+whitespace_in_kwargs = false # default true
+annotate_untyped_fields_with_any = false # default true
+# format_docstrings = false
+# align_struct_field = false
+# align_assignment = false
+# align_conditional = false
+align_pair_arrow = true # default false
+# conditional_to_if = false
+# normalize_line_endings = "auto"
+# align_matrix = false
+# join_lines_based_on_source = false
+trailing_comma = true # default false
+# trailing_zero = true
+# indent_submodule = false
+# separate_kwargs_with_semicolon = false
+surround_whereop_typeparameters = false # default true
+# variable_call_indent = []
+# short_circuit_to_if = false

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -15,35 +15,45 @@ include("constructor.jl")
 include("writer.jl") # write Julia dictionaries to YAML files
 
 const _constructor = Union{Nothing, Dict}
-const _dicttype = Union{Type,Function}
+const _dicttype = Union{Type, Function}
 
 # add a dicttype-aware version of construct_mapping to the constructors
 function _patch_constructors(more_constructors::_constructor, dicttype::_dicttype)
     if more_constructors == nothing
-        more_constructors = Dict{String,Function}()
+        more_constructors = Dict{String, Function}()
     else
         more_constructors = copy(more_constructors) # do not change the outside world
     end
     if !haskey(more_constructors, "tag:yaml.org,2002:map")
         more_constructors["tag:yaml.org,2002:map"] = custom_mapping(dicttype) # map to the custom type
-    elseif dicttype != Dict{Any,Any} # only warn if another type has explicitly been set
+    elseif dicttype != Dict{Any, Any} # only warn if another type has explicitly been set
         @warn "dicttype=$dicttype has no effect because more_constructors has the key \"tag:yaml.org,2002:map\""
     end
     return more_constructors
 end
 
-
 load(ts::TokenStream, constructor::Constructor) =
     construct_document(constructor, compose(EventStream(ts)))
 
-load(input::IO, constructor::Constructor) =
-    load(TokenStream(input), constructor)
+load(input::IO, constructor::Constructor) = load(TokenStream(input), constructor)
 
-load(ts::TokenStream, more_constructors::_constructor = nothing, multi_constructors::Dict = Dict(); dicttype::_dicttype = Dict{Any, Any}, constructorType::Function = SafeConstructor) =
-    load(ts, constructorType(_patch_constructors(more_constructors, dicttype), multi_constructors))
+load(
+    ts::TokenStream,
+    more_constructors::_constructor=nothing,
+    multi_constructors::Dict=Dict();
+    dicttype::_dicttype=Dict{Any, Any},
+    constructorType::Function=SafeConstructor,
+) = load(
+    ts,
+    constructorType(_patch_constructors(more_constructors, dicttype), multi_constructors),
+)
 
-load(input::IO, more_constructors::_constructor = nothing, multi_constructors::Dict = Dict(); kwargs...) =
-    load(TokenStream(input), more_constructors, multi_constructors ; kwargs...)
+load(
+    input::IO,
+    more_constructors::_constructor=nothing,
+    multi_constructors::Dict=Dict();
+    kwargs...,
+) = load(TokenStream(input), more_constructors, multi_constructors; kwargs...)
 
 mutable struct YAMLDocIterator
     input::IO
@@ -58,7 +68,16 @@ mutable struct YAMLDocIterator
     end
 end
 
-YAMLDocIterator(input::IO, more_constructors::_constructor=nothing, multi_constructors::Dict = Dict(); dicttype::_dicttype=Dict{Any, Any}, constructorType::Function = SafeConstructor) = YAMLDocIterator(input, constructorType(_patch_constructors(more_constructors, dicttype), multi_constructors))
+YAMLDocIterator(
+    input::IO,
+    more_constructors::_constructor=nothing,
+    multi_constructors::Dict=Dict();
+    dicttype::_dicttype=Dict{Any, Any},
+    constructorType::Function=SafeConstructor,
+) = YAMLDocIterator(
+    input,
+    constructorType(_patch_constructors(more_constructors, dicttype), multi_constructors),
+)
 
 # Old iteration protocol:
 start(it::YAMLDocIterator) = nothing
@@ -80,11 +99,9 @@ done(it::YAMLDocIterator, state) = it.next_doc === nothing
 iterate(it::YAMLDocIterator) = next(it, start(it))
 iterate(it::YAMLDocIterator, s) = done(it, s) ? nothing : next(it, s)
 
-load_all(input::IO, args...; kwargs...) =
-    YAMLDocIterator(input, args...; kwargs...)
+load_all(input::IO, args...; kwargs...) = YAMLDocIterator(input, args...; kwargs...)
 
-load(input::AbstractString, args...; kwargs...) =
-    load(IOBuffer(input), args...; kwargs...)
+load(input::AbstractString, args...; kwargs...) = load(IOBuffer(input), args...; kwargs...)
 
 load_all(input::AbstractString, args...; kwargs...) =
     load_all(IOBuffer(input), args...; kwargs...)

--- a/src/buffered_input.jl
+++ b/src/buffered_input.jl
@@ -1,8 +1,6 @@
 
-
 # Simple buffered input that allows peeking an arbitrary number of characters
 # ahead by maintaining a typically quite small buffer of a few characters.
-
 
 mutable struct BufferedInput
     input::IO
@@ -15,13 +13,12 @@ mutable struct BufferedInput
     end
 end
 
-
 # Read and buffer n more characters
 function __fill(bi::BufferedInput, bi_input::IO, n::Integer)
     for i in 1:n
         c = eof(bi_input) ? '\0' : read(bi_input, Char)
         if bi.offset + bi.avail + 1 <= length(bi.buffer)
-            bi.buffer[bi.offset + bi.avail + 1] = c
+            bi.buffer[bi.offset+bi.avail+1] = c
         else
             push!(bi.buffer, c)
         end
@@ -37,9 +34,8 @@ function peek(bi::BufferedInput, i::Integer=0)
     if bi.avail < i + 1
         _fill(bi, i + 1 - bi.avail)
     end
-    return bi.buffer[bi.offset + i + 1]
+    return bi.buffer[bi.offset+i+1]
 end
-
 
 # Return the string formed from the first n characters from the current position
 # of the stream.
@@ -47,9 +43,8 @@ function prefix(bi::BufferedInput, n::Integer=1)
     if bi.avail < n + 1
         _fill(bi, n + 1 - bi.avail)
     end
-    return string(bi.buffer[(bi.offset + 1):(bi.offset + n)]...)
+    return string(bi.buffer[(bi.offset+1):(bi.offset+n)]...)
 end
-
 
 # NOPE: This is wrong. What if n > bi.avail
 

--- a/src/composer.jl
+++ b/src/composer.jl
@@ -2,7 +2,6 @@
 include("nodes.jl")
 include("resolver.jl")
 
-
 struct ComposerError
     context::Union{String, Nothing}
     context_mark::Union{Mark, Nothing}
@@ -10,9 +9,13 @@ struct ComposerError
     problem_mark::Union{Mark, Nothing}
     note::Union{String, Nothing}
 
-    function ComposerError(context=nothing, context_mark=nothing,
-                           problem=nothing, problem_mark=nothing,
-                           note=nothing)
+    function ComposerError(
+        context=nothing,
+        context_mark=nothing,
+        problem=nothing,
+        problem_mark=nothing,
+        note=nothing,
+    )
         new(context, context_mark, problem, problem_mark, note)
     end
 end
@@ -24,13 +27,11 @@ function show(io::IO, error::ComposerError)
     print(io, error.problem, " at ", error.problem_mark)
 end
 
-
 mutable struct Composer
     input::EventStream
     anchors::Dict{String, Node}
     resolver::Resolver
 end
-
 
 function compose(events)
     composer = Composer(events, Dict{String, Node}(), Resolver())
@@ -44,7 +45,6 @@ function compose(events)
     node
 end
 
-
 function compose_document(composer::Composer)
     @assert typeof(forward!(composer.input)) == DocumentStartEvent
     node = compose_node(composer)
@@ -53,20 +53,31 @@ function compose_document(composer::Composer)
     node
 end
 
-
 function handle_event(event::AliasEvent, composer)
     anchor = event.anchor
     forward!(composer.input)
-    haskey(composer.anchors, anchor) || throw(ComposerError(
-            nothing, nothing, "found undefined alias '$(anchor)'", event.start_mark))
+    haskey(composer.anchors, anchor) || throw(
+        ComposerError(
+            nothing,
+            nothing,
+            "found undefined alias '$(anchor)'",
+            event.start_mark,
+        ),
+    )
     return composer.anchors[anchor]
 end
 
 handle_error(event, composer, anchor) =
-    anchor !== nothing && haskey(composer.anchors, anchor) && throw(ComposerError(
-                "found duplicate anchor '$(anchor)'; first occurance",
-                composer.anchors[anchor].start_mark, "second occurence",
-                event.start_mark))
+    anchor !== nothing &&
+    haskey(composer.anchors, anchor) &&
+    throw(
+        ComposerError(
+            "found duplicate anchor '$(anchor)'; first occurance",
+            composer.anchors[anchor].start_mark,
+            "second occurence",
+            event.start_mark,
+        ),
+    )
 
 function handle_event(event::ScalarEvent, composer)
     anchor = event.anchor
@@ -88,22 +99,22 @@ end
 
 handle_event(event, composer) = nothing
 
-
 function compose_node(composer::Composer)
     event = peek(composer.input)
     handle_event(event, composer)
 end
 
-
-function _compose_scalar_node(event::ScalarEvent, composer::Composer, anchor::Union{String, Nothing})
+function _compose_scalar_node(
+    event::ScalarEvent,
+    composer::Composer,
+    anchor::Union{String, Nothing},
+)
     tag = event.tag
     if tag === nothing || tag == "!"
-        tag = resolve(composer.resolver, ScalarNode,
-                      event.value, event.implicit)
+        tag = resolve(composer.resolver, ScalarNode, event.value, event.implicit)
     end
 
-    node = ScalarNode(tag, event.value, event.start_mark, event.end_mark,
-                      event.style)
+    node = ScalarNode(tag, event.value, event.start_mark, event.end_mark, event.style)
     if anchor !== nothing
         composer.anchors[anchor] = node
     end
@@ -114,7 +125,6 @@ end
 compose_scalar_node(composer::Composer, anchor::Union{String, Nothing}) =
     _compose_scalar_node(forward!(composer.input), composer, anchor)
 
-
 __compose_sequence_node(event::SequenceEndEvent, composer, node) = false
 function __compose_sequence_node(event::Event, composer, node)
     push!(node.value, compose_node(composer))
@@ -124,12 +134,10 @@ end
 function _compose_sequence_node(start_event::SequenceStartEvent, composer, anchor)
     tag = start_event.tag
     if tag === nothing || tag == "!"
-        tag = resolve(composer.resolver, SequenceNode,
-                      nothing, start_event.implicit)
+        tag = resolve(composer.resolver, SequenceNode, nothing, start_event.implicit)
     end
 
-    node = SequenceNode(tag, Any[], start_event.start_mark, nothing,
-                        start_event.flow_style)
+    node = SequenceNode(tag, Any[], start_event.start_mark, nothing, start_event.flow_style)
     if anchor !== nothing
         composer.anchors[anchor] = node
     end
@@ -147,7 +155,6 @@ end
 compose_sequence_node(composer::Composer, anchor::Union{String, Nothing}) =
     _compose_sequence_node(forward!(composer.input), composer, anchor)
 
-
 __compose_mapping_node(event::MappingEndEvent, composer, node) = false
 function __compose_mapping_node(event::Event, composer, node)
     item_key = compose_node(composer)
@@ -156,15 +163,17 @@ function __compose_mapping_node(event::Event, composer, node)
     true
 end
 
-function _compose_mapping_node(start_event::MappingStartEvent, composer::Composer, anchor::Union{String, Nothing})
+function _compose_mapping_node(
+    start_event::MappingStartEvent,
+    composer::Composer,
+    anchor::Union{String, Nothing},
+)
     tag = start_event.tag
     if tag === nothing || tag == "!"
-        tag = resolve(composer.resolver, MappingNode,
-                      nothing, start_event.implicit)
+        tag = resolve(composer.resolver, MappingNode, nothing, start_event.implicit)
     end
 
-    node = MappingNode(tag, Any[], start_event.start_mark, nothing,
-                       start_event.flow_style)
+    node = MappingNode(tag, Any[], start_event.start_mark, nothing, start_event.flow_style)
     if anchor !== nothing
         composer.anchors[anchor] = node
     end

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -6,12 +6,15 @@ struct ConstructorError
     problem_mark::Union{Mark, Nothing}
     note::Union{String, Nothing}
 
-    function ConstructorError(context=nothing, context_mark=nothing,
-                              problem=nothing, problem_mark=nothing,
-                              note=nothing)
+    function ConstructorError(
+        context=nothing,
+        context_mark=nothing,
+        problem=nothing,
+        problem_mark=nothing,
+        note=nothing,
+    )
         new(context, context_mark, problem, problem_mark, note)
     end
-
 end
 
 function show(io::IO, error::ConstructorError)
@@ -21,33 +24,43 @@ function show(io::IO, error::ConstructorError)
     print(io, error.problem, " at ", error.problem_mark)
 end
 
-
 mutable struct Constructor
     constructed_objects::Dict{Node, Any}
     recursive_objects::Set{Node}
     yaml_constructors::Dict{Union{String, Nothing}, Function}
     yaml_multi_constructors::Dict{Union{String, Nothing}, Function}
 
-    function Constructor(single_constructors = Dict(), multi_constructors = Dict())
-        new(Dict{Node, Any}(), Set{Node}(),
-            convert(Dict{Union{String, Nothing},Function}, single_constructors),
-            convert(Dict{Union{String, Nothing},Function}, multi_constructors))
+    function Constructor(single_constructors=Dict(), multi_constructors=Dict())
+        new(
+            Dict{Node, Any}(),
+            Set{Node}(),
+            convert(Dict{Union{String, Nothing}, Function}, single_constructors),
+            convert(Dict{Union{String, Nothing}, Function}, multi_constructors),
+        )
     end
 end
 
-
-function add_constructor!(func::Function, constructor::Constructor, tag::Union{String, Nothing})
+function add_constructor!(
+    func::Function,
+    constructor::Constructor,
+    tag::Union{String, Nothing},
+)
     constructor.yaml_constructors[tag] = func
     constructor
 end
 
-function add_multi_constructor!(func::Function, constructor::Constructor, tag::Union{String, Nothing})
+function add_multi_constructor!(
+    func::Function,
+    constructor::Constructor,
+    tag::Union{String, Nothing},
+)
     constructor.yaml_multi_constructors[tag] = func
     constructor
 end
 
-Constructor(::Nothing) = Constructor(Dict{String,Function}())
-SafeConstructor(constructors::Dict = Dict(), multi_constructors::Dict = Dict()) = Constructor(merge(copy(default_yaml_constructors), constructors), multi_constructors)
+Constructor(::Nothing) = Constructor(Dict{String, Function}())
+SafeConstructor(constructors::Dict=Dict(), multi_constructors::Dict=Dict()) =
+    Constructor(merge(copy(default_yaml_constructors), constructors), multi_constructors)
 
 function construct_document(constructor::Constructor, node::Node)
     data = construct_object(constructor, node)
@@ -56,16 +69,20 @@ function construct_document(constructor::Constructor, node::Node)
     data
 end
 
-
 function construct_object(constructor::Constructor, node::Node)
     if haskey(constructor.constructed_objects, node)
         return constructor.constructed_objects[node]
     end
 
     if in(node, constructor.recursive_objects)
-        throw(ConstructorError(nothing, nothing,
-                               "found unconstructable recursive node",
-                               node.start_mark))
+        throw(
+            ConstructorError(
+                nothing,
+                nothing,
+                "found unconstructable recursive node",
+                node.start_mark,
+            ),
+        )
     end
 
     push!(constructor.recursive_objects, node)
@@ -76,7 +93,7 @@ function construct_object(constructor::Constructor, node::Node)
     else
         for (tag_prefix, node_const) in constructor.yaml_multi_constructors
             if tag_prefix !== nothing && startswith(node.tag, tag_prefix)
-                tag_suffix = node.tag[length(tag_prefix) + 1:end]
+                tag_suffix = node.tag[length(tag_prefix)+1:end]
                 node_constructor = node_const
                 break
             end
@@ -112,27 +129,34 @@ function construct_object(constructor::Constructor, node::Node)
     data
 end
 
-
 function construct_scalar(constructor::Constructor, node::Node)
     if !(node isa ScalarNode)
-        throw(ConstructorError(nothing, nothing,
-                               "expected a scalar node, but found $(typeof(node))",
-                               node.start_mark))
+        throw(
+            ConstructorError(
+                nothing,
+                nothing,
+                "expected a scalar node, but found $(typeof(node))",
+                node.start_mark,
+            ),
+        )
     end
     node.value
 end
 
-
 function construct_sequence(constructor::Constructor, node::Node)
     if !(node isa SequenceNode)
-        throw(ConstructorError(nothing, nothing,
-                               "expected a sequence node, but found $(typeof(node))",
-                               node.start_mark))
+        throw(
+            ConstructorError(
+                nothing,
+                nothing,
+                "expected a sequence node, but found $(typeof(node))",
+                node.start_mark,
+            ),
+        )
     end
 
     [construct_object(constructor, child) for child in node.value]
 end
-
 
 function flatten_mapping(node::MappingNode)
     merge = []
@@ -148,10 +172,14 @@ function flatten_mapping(node::MappingNode)
                 submerge = []
                 for subnode in value_node.value
                     if typeof(subnode) != MappingNode
-                        throw(ConstructorError("while constructing a mapping",
-                                               node.start_mark,
-                                               "expected a mapping node, but found $(typeof(subnode))",
-                                               subnode.start_mark))
+                        throw(
+                            ConstructorError(
+                                "while constructing a mapping",
+                                node.start_mark,
+                                "expected a mapping node, but found $(typeof(subnode))",
+                                subnode.start_mark,
+                            ),
+                        )
                     end
                     flatten_mapping(subnode)
                     push!(submerge, subnode.value)
@@ -173,8 +201,11 @@ function flatten_mapping(node::MappingNode)
     end
 end
 
-
-function construct_mapping(dicttype::Union{Type,Function}, constructor::Constructor, node::MappingNode)
+function construct_mapping(
+    dicttype::Union{Type, Function},
+    constructor::Constructor,
+    node::MappingNode,
+)
     flatten_mapping(node)
     mapping = dicttype()
     for (key_node, value_node) in node.value
@@ -184,43 +215,55 @@ function construct_mapping(dicttype::Union{Type,Function}, constructor::Construc
             try
                 key = keytype(mapping)(key) # try to cast
             catch
-                throw(ConstructorError(nothing, nothing,
-                                       "Cannot cast $key to the key type of $dicttype",
-                                       node.start_mark))
+                throw(
+                    ConstructorError(
+                        nothing,
+                        nothing,
+                        "Cannot cast $key to the key type of $dicttype",
+                        node.start_mark,
+                    ),
+                )
             end
         end
         try
             mapping[key] = value
         catch
-            throw(ConstructorError(nothing, nothing,
-                                   "Cannot store $key=>$value in $dicttype",
-                                   node.start_mark))
+            throw(
+                ConstructorError(
+                    nothing,
+                    nothing,
+                    "Cannot store $key=>$value in $dicttype",
+                    node.start_mark,
+                ),
+            )
         end
     end
     mapping
 end
 
-construct_mapping(constructor::Constructor, node::Node) = construct_mapping(Dict{Any,Any}, constructor, node)
+construct_mapping(constructor::Constructor, node::Node) =
+    construct_mapping(Dict{Any, Any}, constructor, node)
 
 # create a construct_mapping instance for a specific dicttype
 custom_mapping(dicttype::Type{D}) where D <: AbstractDict =
     (constructor::Constructor, node::Node) -> construct_mapping(dicttype, constructor, node)
 function custom_mapping(dicttype::Function)
-    dicttype_test = try dicttype() catch
+    dicttype_test = try
+        dicttype()
+    catch
         throw(ArgumentError("The dicttype Function cannot be called without arguments"))
     end
     if !(dicttype_test isa AbstractDict)
         throw(ArgumentError("The dicttype Function does not return an AbstractDict"))
     end
-    return (constructor::Constructor, node::Node) -> construct_mapping(dicttype, constructor, node)
+    return (constructor::Constructor, node::Node) ->
+        construct_mapping(dicttype, constructor, node)
 end
-
 
 function construct_yaml_null(constructor::Constructor, node::Node)
     construct_scalar(constructor, node)
     nothing
 end
-
 
 const bool_values = Dict(
     "yes"   => true,
@@ -228,14 +271,13 @@ const bool_values = Dict(
     "true"  => true,
     "false" => false,
     "on"    => true,
-    "off"   => false )
-
+    "off"   => false,
+)
 
 function construct_yaml_bool(constructor::Constructor, node::Node)
     value = construct_scalar(constructor, node)
     bool_values[lowercase(value)]
 end
-
 
 function construct_yaml_int(constructor::Constructor, node::Node)
     value = string(construct_scalar(constructor, node))
@@ -244,20 +286,19 @@ function construct_yaml_int(constructor::Constructor, node::Node)
     if in(':', value)
         # TODO
         #throw(ConstructorError(nothing, nothing,
-            #"sexagesimal integers not yet implemented", node.start_mark))
+        #"sexagesimal integers not yet implemented", node.start_mark))
         warn("sexagesimal integers not yet implemented. Returning String.")
         return value
     end
 
     if length(value) > 2 && value[1] == '0' && (value[2] == 'x' || value[2] == 'X')
-        return parse(Int, value[3:end], base = 16)
+        return parse(Int, value[3:end], base=16)
     elseif length(value) > 1 && value[1] == '0'
-        return parse(Int, value, base = 8)
+        return parse(Int, value, base=8)
     else
-        return parse(Int, value, base = 10)
+        return parse(Int, value, base=10)
     end
 end
-
 
 function construct_yaml_float(constructor::Constructor, node::Node)
     value = string(construct_scalar(constructor, node))
@@ -287,32 +328,35 @@ function construct_yaml_float(constructor::Constructor, node::Node)
     return parse(Float64, value)
 end
 
-
-const timestamp_pat =
-    r"^(\d{4})-    (?# year)
-       (\d\d?)-    (?# month)
-       (\d\d?)     (?# day)
-      (?:
-        (?:[Tt]|[ \t]+)
-        (\d\d?):      (?# hour)
-        (\d\d):       (?# minute)
-        (\d\d)        (?# second)
-        (?:\.(\d*))?  (?# fraction)
-        (?:
-          [ \t]*(Z|(?:[+\-])(\d\d?)
-            (?:
-                :(\d\d)
-            )?)
-        )?
-      )?$"x
-
+const timestamp_pat = r"^(\d{4})-    (?# year)
+                         (\d\d?)-    (?# month)
+                         (\d\d?)     (?# day)
+                        (?:
+                          (?:[Tt]|[ \t]+)
+                          (\d\d?):      (?# hour)
+                          (\d\d):       (?# minute)
+                          (\d\d)        (?# second)
+                          (?:\.(\d*))?  (?# fraction)
+                          (?:
+                            [ \t]*(Z|(?:[+\-])(\d\d?)
+                              (?:
+                                  :(\d\d)
+                              )?)
+                          )?
+                        )?$"x
 
 function construct_yaml_timestamp(constructor::Constructor, node::Node)
     value = construct_scalar(constructor, node)
     mat = match(timestamp_pat, value)
     if mat === nothing
-        throw(ConstructorError(nothing, nothing,
-            "could not make sense of timestamp format", node.start_mark))
+        throw(
+            ConstructorError(
+                nothing,
+                nothing,
+                "could not make sense of timestamp format",
+                node.start_mark,
+            ),
+        )
     end
 
     yr = parse(Int, mat.captures[1])
@@ -357,52 +401,67 @@ function construct_yaml_timestamp(constructor::Constructor, node::Node)
     return DateTime(yr, mn, dy, h, m, s, ms)
 end
 
-
 function construct_yaml_omap(constructor::Constructor, node::Node)
-    throw(ConstructorError(nothing, nothing,
-        "omap type not yet implemented", node.start_mark))
+    throw(
+        ConstructorError(
+            nothing,
+            nothing,
+            "omap type not yet implemented",
+            node.start_mark,
+        ),
+    )
 end
-
 
 function construct_yaml_pairs(constructor::Constructor, node::Node)
-    throw(ConstructorError(nothing, nothing,
-        "pairs type not yet implemented", node.start_mark))
+    throw(
+        ConstructorError(
+            nothing,
+            nothing,
+            "pairs type not yet implemented",
+            node.start_mark,
+        ),
+    )
 end
-
 
 function construct_yaml_set(constructor::Constructor, node::Node)
-    throw(ConstructorError(nothing, nothing,
-        "set type not yet implemented", node.start_mark))
+    throw(
+        ConstructorError(nothing, nothing, "set type not yet implemented", node.start_mark),
+    )
 end
-
 
 function construct_yaml_str(constructor::Constructor, node::Node)
     string(construct_scalar(constructor, node))
 end
 
-
 function construct_yaml_seq(constructor::Constructor, node::Node)
     construct_sequence(constructor, node)
 end
-
 
 function construct_yaml_map(constructor::Constructor, node::Node)
     construct_mapping(constructor, node)
 end
 
-
 function construct_yaml_object(constructor::Constructor, node::Node)
-    throw(ConstructorError(nothing, nothing,
-        "object type not yet implemented", node.start_mark))
+    throw(
+        ConstructorError(
+            nothing,
+            nothing,
+            "object type not yet implemented",
+            node.start_mark,
+        ),
+    )
 end
-
 
 function construct_undefined(constructor::Constructor, node::Node)
-    throw(ConstructorError(nothing, nothing,
-        "could not determine a constructor for the tag '$(node.tag)'",
-        node.start_mark))
+    throw(
+        ConstructorError(
+            nothing,
+            nothing,
+            "could not determine a constructor for the tag '$(node.tag)'",
+            node.start_mark,
+        ),
+    )
 end
-
 
 function construct_yaml_binary(constructor::Constructor, node::Node)
     value = replace(string(construct_scalar(constructor, node)), "\n" => "")
@@ -410,17 +469,17 @@ function construct_yaml_binary(constructor::Constructor, node::Node)
 end
 
 const default_yaml_constructors = Dict{Union{String, Nothing}, Function}(
-        "tag:yaml.org,2002:null"      => construct_yaml_null,
-        "tag:yaml.org,2002:bool"      => construct_yaml_bool,
-        "tag:yaml.org,2002:int"       => construct_yaml_int,
-        "tag:yaml.org,2002:float"     => construct_yaml_float,
-        "tag:yaml.org,2002:binary"    => construct_yaml_binary,
-        "tag:yaml.org,2002:timestamp" => construct_yaml_timestamp,
-        "tag:yaml.org,2002:omap"      => construct_yaml_omap,
-        "tag:yaml.org,2002:pairs"     => construct_yaml_pairs,
-        "tag:yaml.org,2002:set"       => construct_yaml_set,
-        "tag:yaml.org,2002:str"       => construct_yaml_str,
-        "tag:yaml.org,2002:seq"       => construct_yaml_seq,
-        "tag:yaml.org,2002:map"       => construct_yaml_map,
-        nothing                       => construct_undefined,
-    )
+    "tag:yaml.org,2002:null"      => construct_yaml_null,
+    "tag:yaml.org,2002:bool"      => construct_yaml_bool,
+    "tag:yaml.org,2002:int"       => construct_yaml_int,
+    "tag:yaml.org,2002:float"     => construct_yaml_float,
+    "tag:yaml.org,2002:binary"    => construct_yaml_binary,
+    "tag:yaml.org,2002:timestamp" => construct_yaml_timestamp,
+    "tag:yaml.org,2002:omap"      => construct_yaml_omap,
+    "tag:yaml.org,2002:pairs"     => construct_yaml_pairs,
+    "tag:yaml.org,2002:set"       => construct_yaml_set,
+    "tag:yaml.org,2002:str"       => construct_yaml_str,
+    "tag:yaml.org,2002:seq"       => construct_yaml_seq,
+    "tag:yaml.org,2002:map"       => construct_yaml_map,
+    nothing                       => construct_undefined,
+)

--- a/src/events.jl
+++ b/src/events.jl
@@ -7,12 +7,10 @@ struct StreamStartEvent <: Event
     encoding::String
 end
 
-
 struct StreamEndEvent <: Event
     start_mark::Mark
     end_mark::Mark
 end
-
 
 struct DocumentStartEvent <: Event
     start_mark::Mark
@@ -21,13 +19,16 @@ struct DocumentStartEvent <: Event
     version::Union{Tuple, Nothing}
     tags::Union{Dict{String, String}, Nothing}
 
-    function DocumentStartEvent(start_mark::Mark,end_mark::Mark,
-                                explicit::Bool, version=nothing,
-                                tags=nothing)
+    function DocumentStartEvent(
+        start_mark::Mark,
+        end_mark::Mark,
+        explicit::Bool,
+        version=nothing,
+        tags=nothing,
+    )
         new(start_mark, end_mark, explicit, version, tags)
     end
 end
-
 
 struct DocumentEndEvent <: Event
     start_mark::Mark
@@ -35,13 +36,11 @@ struct DocumentEndEvent <: Event
     explicit::Bool
 end
 
-
 struct AliasEvent <: Event
     start_mark::Mark
     end_mark::Mark
     anchor::Union{String, Nothing}
 end
-
 
 struct ScalarEvent <: Event
     start_mark::Mark
@@ -53,7 +52,6 @@ struct ScalarEvent <: Event
     style::Union{Char, Nothing}
 end
 
-
 struct SequenceStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
@@ -63,12 +61,10 @@ struct SequenceStartEvent <: Event
     flow_style::Bool
 end
 
-
 struct SequenceEndEvent <: Event
     start_mark::Mark
     end_mark::Mark
 end
-
 
 struct MappingStartEvent <: Event
     start_mark::Mark
@@ -79,10 +75,7 @@ struct MappingStartEvent <: Event
     flow_style::Bool
 end
 
-
 struct MappingEndEvent <: Event
     start_mark::Mark
     end_mark::Mark
 end
-
-

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -9,7 +9,6 @@ mutable struct ScalarNode <: Node
     style::Union{Char, Nothing}
 end
 
-
 mutable struct SequenceNode <: Node
     tag::String
     value::Vector
@@ -17,7 +16,6 @@ mutable struct SequenceNode <: Node
     end_mark::Union{Mark, Nothing}
     flow_style::Bool
 end
-
 
 mutable struct MappingNode <: Node
     tag::String

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -10,5 +10,5 @@ length(q::Queue) = length(q.data)
 peek(q::Queue) = q.data[1]
 enqueue!(q::Queue{T}, value::T) where T = push!(q.data, value)
 # Enqueue into kth place.
-enqueue!(q::Queue{T}, value::T, k::Integer) where T = insert!(q.data, k+1, value)
+enqueue!(q::Queue{T}, value::T, k::Integer) where T = insert!(q.data, k + 1, value)
 dequeue!(q::Queue) = popfirst!(q.data)

--- a/src/resolver.jl
+++ b/src/resolver.jl
@@ -1,71 +1,59 @@
 
-
 # TODO:
 # This is a punt for now. It does not handle any sort of custom resolving tags,
 # only matching default implicits.
-
 
 const DEFAULT_SCALAR_TAG = "tag:yaml.org,2002:str"
 const DEFAULT_SEQUENCE_TAG = "tag:yaml.org,2002:seq"
 const DEFAULT_MAPPING_TAG = "tag:yaml.org,2002:map"
 
-
-const default_implicit_resolvers =
-    [
-         ("tag:yaml.org,2002:bool",
-          r"^(?:true|True|TRUE|false|False|FALSE)$"x),
-
-         ("tag:yaml.org,2002:int",
-          r"^(?:[-+]?0b[0-1_]+
-            |[-+]? [0-9]+
-            |0o [0-7]+
-            |0x [0-9a-fA-F]+)$"x),
-
-         ("tag:yaml.org,2002:float",
-          r"^(?:[-+]? ( \. [0-9]+ | [0-9]+ ( \. [0-9]* )? ) ( [eE] [-+]? [0-9]+ )?
-            |[-+]? (?: \.inf | \.Inf | \.INF )
-            |\.nan | \.NaN | \.NAN)$"x),
-
-         ("tag:yaml.org,2002:merge",
-          r"^(?:<<)$"),
-
-         ("tag:yaml.org,2002:null",
-          r"^(?:~|null|Null|NULL|)$"x),
-
-         ("tag:yaml.org,2002:timestamp",
-          r"^(\d{4})-    (?# year)
-             (\d\d?)-    (?# month)
-             (\d\d?)     (?# day)
+const default_implicit_resolvers = [
+    ("tag:yaml.org,2002:bool", r"^(?:true|True|TRUE|false|False|FALSE)$"x),
+    (
+        "tag:yaml.org,2002:int",
+        r"^(?:[-+]?0b[0-1_]+
+          |[-+]? [0-9]+
+          |0o [0-7]+
+          |0x [0-9a-fA-F]+)$"x,
+    ),
+    (
+        "tag:yaml.org,2002:float",
+        r"^(?:[-+]? ( \. [0-9]+ | [0-9]+ ( \. [0-9]* )? ) ( [eE] [-+]? [0-9]+ )?
+          |[-+]? (?: \.inf | \.Inf | \.INF )
+          |\.nan | \.NaN | \.NAN)$"x,
+    ),
+    ("tag:yaml.org,2002:merge", r"^(?:<<)$"),
+    ("tag:yaml.org,2002:null", r"^(?:~|null|Null|NULL|)$"x),
+    (
+        "tag:yaml.org,2002:timestamp",
+        r"^(\d{4})-    (?# year)
+           (\d\d?)-    (?# month)
+           (\d\d?)     (?# day)
+          (?:
+            (?:[Tt]|[ \t]+)
+            (\d\d?):      (?# hour)
+            (\d\d):       (?# minute)
+            (\d\d)        (?# second)
+            (?:\.(\d*))?  (?# fraction)
             (?:
-              (?:[Tt]|[ \t]+)
-              (\d\d?):      (?# hour)
-              (\d\d):       (?# minute)
-              (\d\d)        (?# second)
-              (?:\.(\d*))?  (?# fraction)
-              (?:
-                [ \t]*(Z|([+\-])(\d\d?)
-                  (?:
-                      :(\d\d)
-                  )?)
-              )?
-            )?$"x),
-
-         ("tag:yaml.org,2002:value",
-          r"^(?:=)$"),
-
-         ("tag:yaml.org,2002:yaml",
-          r"^(?:!|&|\*)$")
-    ]
-
+              [ \t]*(Z|([+\-])(\d\d?)
+                (?:
+                    :(\d\d)
+                )?)
+            )?
+          )?$"x,
+    ),
+    ("tag:yaml.org,2002:value", r"^(?:=)$"),
+    ("tag:yaml.org,2002:yaml", r"^(?:!|&|\*)$"),
+]
 
 mutable struct Resolver
-    implicit_resolvers::Vector{Tuple{String,Regex}}
+    implicit_resolvers::Vector{Tuple{String, Regex}}
 
     function Resolver()
         new(copy(default_implicit_resolvers))
     end
 end
-
 
 function resolve(resolver::Resolver, ::Type{ScalarNode}, value, implicit)
     if implicit[1]
@@ -79,7 +67,6 @@ function resolve(resolver::Resolver, ::Type{ScalarNode}, value, implicit)
     DEFAULT_SCALAR_TAG
 end
 
-
 function resolve(resolver::Resolver, ::Type{SequenceNode}, value, implicit)
     DEFAULT_SEQUENCE_TAG
 end
@@ -87,4 +74,3 @@ end
 function resolve(resolver::Resolver, ::Type{MappingNode}, value, implicit)
     DEFAULT_MAPPING_TAG
 end
-

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -3,7 +3,6 @@
 # Each token must include at minimum member "span::Span".
 abstract type Token end
 
-
 # The '%YAML' directive.
 struct DirectiveToken <: Token
     span::Span
@@ -23,7 +22,7 @@ end
 
 # '\uFEFF'
 struct ByteOrderMarkToken <: Token
-	span::Span
+    span::Span
 end
 
 # The stream start

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -112,12 +112,10 @@ _print(io::IO, val::Float64, level::Int=0, ignore_level::Bool=false) =
         println(io, "-.inf")
     end
 
-_print(io::IO, val::Nothing, level::Int=0, ignore_level::Bool=false) =
-    println(io, "~") # this is what the YAML parser interprets as nothing
+_print(io::IO, val::Nothing, level::Int=0, ignore_level::Bool=false) = println(io, "~") # this is what the YAML parser interprets as nothing
 
 # _print any other single value
-_print(io::IO, val::Any, level::Int=0, ignore_level::Bool=false) =
-    println(io, string(val)) # no indentation is required
+_print(io::IO, val::Any, level::Int=0, ignore_level::Bool=false) = println(io, string(val)) # no indentation is required
 
 # add indentation to a string
 _indent(str::AbstractString, level::Int, ignore_level::Bool=false) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,9 +58,8 @@ const test_write_ignored = [
     "cartesian",
     "ar1",
     "ar1_cartesian",
-    "multi-constructor"
+    "multi-constructor",
 ]
-
 
 function equivalent(xs::AbstractDict, ys::AbstractDict)
     if Set(collect(keys(xs))) != Set(collect(keys(ys)))
@@ -78,7 +77,6 @@ function equivalent(xs::AbstractDict, ys::AbstractDict)
     true
 end
 
-
 function equivalent(xs::AbstractArray, ys::AbstractArray)
     if length(xs) != length(ys)
         @info "Not equivalent" length(xs) length(ys)
@@ -95,11 +93,9 @@ function equivalent(xs::AbstractArray, ys::AbstractArray)
     true
 end
 
-
 function equivalent(x::Float64, y::Float64)
     isnan(x) && isnan(y) ? true : x == y
 end
-
 
 function equivalent(x::AbstractString, y::AbstractString)
     while endswith(x, "\n")
@@ -115,20 +111,17 @@ function equivalent(x, y)
     x == y
 end
 
-
 # test custom tags
-function construct_type_map(t::Symbol, constructor::YAML.Constructor,
-                            node::YAML.Node)
+function construct_type_map(t::Symbol, constructor::YAML.Constructor, node::YAML.Node)
     mapping = YAML.construct_mapping(constructor, node)
     mapping[:tag] = t
     mapping
 end
 
 function TestConstructor()
-    pairs = [("!Cartesian", :Cartesian),
-             ("!AR1", :AR1)]
+    pairs = [("!Cartesian", :Cartesian), ("!AR1", :AR1)]
     ret = YAML.SafeConstructor()
-    for (t,s) in pairs
+    for (t, s) in pairs
         YAML.add_constructor!(ret, t) do c, n
             construct_type_map(s, c, n)
         end
@@ -142,15 +135,12 @@ function TestConstructor()
 end
 
 const more_constructors = let
-    pairs = [("!Cartesian", :Cartesian),
-             ("!AR1", :AR1)]
-    Dict{String,Function}([(t, (c, n) -> construct_type_map(s, c, n))
-                           for (t, s) in pairs])
+    pairs = [("!Cartesian", :Cartesian), ("!AR1", :AR1)]
+    Dict{String, Function}([(t, (c, n) -> construct_type_map(s, c, n)) for (t, s) in pairs])
 end
 
-const multi_constructors = Dict{String, Function}(
-    "!addtag:" => (c, t, n) -> construct_type_map(Symbol(t), c, n)
-)
+const multi_constructors =
+    Dict{String, Function}("!addtag:" => (c, t, n) -> construct_type_map(Symbol(t), c, n))
 
 # write a file, then load its contents to be tested again
 function write_and_load(data::Any)
@@ -172,16 +162,15 @@ const testdir = dirname(@__FILE__)
 
     @testset "Load from File" begin
         @test begin
-            data = YAML.load_file(
-                joinpath(testdir, string(test, ".data")),
-                TestConstructor()
-            )
+            data =
+                YAML.load_file(joinpath(testdir, string(test, ".data")), TestConstructor())
             equivalent(data, expected)
         end
         @test begin
             dictData = YAML.load_file(
                 joinpath(testdir, string(test, ".data")),
-                more_constructors, multi_constructors
+                more_constructors,
+                multi_constructors,
             )
             equivalent(dictData, expected)
         end
@@ -189,18 +178,12 @@ const testdir = dirname(@__FILE__)
 
     @testset "Load from String" begin
         @test begin
-            data = YAML.load(
-                yamlString,
-                TestConstructor()
-            )
+            data = YAML.load(yamlString, TestConstructor())
             equivalent(data, expected)
         end
 
         @test begin
-            dictData = YAML.load(
-                yamlString,
-                more_constructors, multi_constructors
-            )
+            dictData = YAML.load(yamlString, more_constructors, multi_constructors)
             equivalent(dictData, expected)
         end
     end
@@ -209,7 +192,7 @@ const testdir = dirname(@__FILE__)
         @test begin
             data = YAML.load_all_file(
                 joinpath(testdir, string(test, ".data")),
-                TestConstructor()
+                TestConstructor(),
             )
             equivalent(first(data), expected)
         end
@@ -217,7 +200,8 @@ const testdir = dirname(@__FILE__)
         @test begin
             dictData = YAML.load_all_file(
                 joinpath(testdir, string(test, ".data")),
-                more_constructors, multi_constructors
+                more_constructors,
+                multi_constructors,
             )
             equivalent(first(dictData), expected)
         end
@@ -225,29 +209,22 @@ const testdir = dirname(@__FILE__)
 
     @testset "Load All from String" begin
         @test begin
-            data = YAML.load_all(
-                yamlString,
-                TestConstructor()
-            )
+            data = YAML.load_all(yamlString, TestConstructor())
             equivalent(first(data), expected)
         end
 
         @test begin
-            dictData = YAML.load_all(
-                yamlString,
-                more_constructors, multi_constructors
-            )
+            dictData = YAML.load_all(yamlString, more_constructors, multi_constructors)
             equivalent(first(dictData), expected)
         end
     end
-
 
     if !in(test, test_write_ignored)
         @testset "Writing" begin
             @test begin
                 data = YAML.load_file(
                     joinpath(testdir, string(test, ".data")),
-                    more_constructors
+                    more_constructors,
                 )
                 equivalent(write_and_load(data), expected)
             end
@@ -257,9 +234,7 @@ const testdir = dirname(@__FILE__)
     end
 end
 
-const encodings = [
-    enc"UTF-8", enc"UTF-16BE", enc"UTF-16LE", enc"UTF-32BE", enc"UTF-32LE"
-]
+const encodings = [enc"UTF-8", enc"UTF-16BE", enc"UTF-16LE", enc"UTF-32BE", enc"UTF-32LE"]
 @testset for encoding in encodings
     data = encode("test", encoding)
     @test YAML.detect_encoding(IOBuffer(data)) == encoding
@@ -292,21 +267,22 @@ end
 
 # test that an OrderedDict is written in the correct order
 using OrderedCollections, DataStructures
-@test strip(YAML.yaml(OrderedDict(:c => 3, :b => 2, :a => 1))) == join(["c: 3", "b: 2", "a: 1"], "\n")
+@test strip(YAML.yaml(OrderedDict(:c => 3, :b => 2, :a => 1))) ==
+      join(["c: 3", "b: 2", "a: 1"], "\n")
 
 # test that arbitrary dicttypes can be parsed
 const dicttypes = [
-    Dict{Any,Any},
-    Dict{String,Any},
-    Dict{Symbol,Any},
-    OrderedDict{String,Any},
-    () -> DefaultDict{String,Any}(Missing),
+    Dict{Any, Any},
+    Dict{String, Any},
+    Dict{Symbol, Any},
+    OrderedDict{String, Any},
+    () -> DefaultDict{String, Any}(Missing),
 ]
 @testset for dicttype in dicttypes
     data = YAML.load_file(
         joinpath(testdir, "nested-dicts.data"),
         more_constructors;
-        dicttype=dicttype
+        dicttype=dicttype,
     )
     if typeof(dicttype) <: Function
         dicttype = typeof(dicttype())
@@ -319,8 +295,8 @@ const dicttypes = [
 
     # type-specific tests
     if dicttype <: OrderedDict
-        @test [k for (k,v) in data] == [_key("outer"), _key("anything_later")] # correct order
-    elseif [k for (k,v) in data] == [_key("outer"), _key("anything_later")]
+        @test [k for (k, v) in data] == [_key("outer"), _key("anything_later")] # correct order
+    elseif [k for (k, v) in data] == [_key("outer"), _key("anything_later")]
         @warn "Test of OrderedDict might not be discriminative: the order is also correct in $dicttype"
     end
     if dicttype <: DefaultDict
@@ -328,34 +304,38 @@ const dicttypes = [
     end
 end
 
-const test_errors = [
-    "invalid-tag"
-]
+const test_errors = ["invalid-tag"]
 
 @testset "YAML Errors" "error test = $test" for test in test_errors
     @test_throws YAML.ConstructorError YAML.load_file(
         joinpath(testdir, string(test, ".data")),
-        TestConstructor()
+        TestConstructor(),
     )
 end
 
 @testset "Custom Constructor" begin
-
     function MySafeConstructor()
         yaml_constructors = copy(YAML.default_yaml_constructors)
         delete!(yaml_constructors, nothing)
         YAML.Constructor(yaml_constructors)
     end
 
-
     function MyReallySafeConstructor()
         yaml_constructors = copy(YAML.default_yaml_constructors)
         delete!(yaml_constructors, nothing)
         ret = YAML.Constructor(yaml_constructors)
-        YAML.add_multi_constructor!(ret, nothing) do constructor::YAML.Constructor, tag, node
-            throw(YAML.ConstructorError(nothing, nothing,
-                "could not determine a constructor for the tag '$(tag)'",
-                node.start_mark))
+        YAML.add_multi_constructor!(
+            ret,
+            nothing,
+        ) do constructor::YAML.Constructor, tag, node
+            throw(
+                YAML.ConstructorError(
+                    nothing,
+                    nothing,
+                    "could not determine a constructor for the tag '$(tag)'",
+                    node.start_mark,
+                ),
+            )
         end
         ret
     end
@@ -368,51 +348,54 @@ end
             - test2
     """
 
-    expected = Dict{Any,Any}("Test" => Dict{Any,Any}("test2"=>["test1", "test2"],"test1"=>"data"))
+    expected = Dict{Any, Any}(
+        "Test" => Dict{Any, Any}("test2" => ["test1", "test2"], "test1" => "data"),
+    )
 
     @test equivalent(YAML.load(yamlString, MySafeConstructor()), expected)
-    @test_throws YAML.ConstructorError YAML.load(
-        yamlString,
-        MyReallySafeConstructor()
-    )
+    @test_throws YAML.ConstructorError YAML.load(yamlString, MyReallySafeConstructor())
 end
-
 
 # also check that things break correctly
 @test_throws YAML.ConstructorError YAML.load_file(
     joinpath(testdir, "nested-dicts.data"),
     more_constructors;
-    dicttype=Dict{Float64,Any}
+    dicttype=Dict{Float64, Any},
 )
 
 @test_throws YAML.ConstructorError YAML.load_file(
     joinpath(testdir, "nested-dicts.data"),
     more_constructors;
-    dicttype=Dict{Any,Float64}
+    dicttype=Dict{Any, Float64},
 )
 
 @test_throws ArgumentError YAML.load_file(
     joinpath(testdir, "nested-dicts.data"),
     more_constructors;
-    dicttype=(mistaken_argument) -> DefaultDict{String,Any}(mistaken_argument)
+    dicttype=(mistaken_argument) -> DefaultDict{String, Any}(mistaken_argument),
 )
 
 @test_throws ArgumentError YAML.load_file(
     joinpath(testdir, "nested-dicts.data"),
     more_constructors;
-    dicttype=() -> 3.0 # wrong type
+    dicttype=() -> 3.0, # wrong type
 )
 
 # issue 81
-dict_content = ["key1" => [Dict("subkey1" => "subvalue1", "subkey2" => "subvalue2"), Dict()], "key2" => "value2"]
+dict_content = [
+    "key1" => [Dict("subkey1" => "subvalue1", "subkey2" => "subvalue2"), Dict()],
+    "key2" => "value2",
+]
 order_one = OrderedDict(dict_content...)
-order_two = OrderedDict(dict_content[[2,1]]...) # reverse order
+order_two = OrderedDict(dict_content[[2, 1]]...) # reverse order
 @test YAML.yaml(order_one) != YAML.yaml(order_two)
 @test YAML.load(YAML.yaml(order_one)) == YAML.load(YAML.yaml(order_two))
 
 # issue 89 - quotes in strings
-@test YAML.load(YAML.yaml(Dict("a" => """a "quoted" string""")))["a"] == """a "quoted" string"""
-@test YAML.load(YAML.yaml(Dict("a" => """a \\"quoted\\" string""")))["a"] == """a \\"quoted\\" string"""
+@test YAML.load(YAML.yaml(Dict("a" => """a "quoted" string""")))["a"] ==
+      """a "quoted" string"""
+@test YAML.load(YAML.yaml(Dict("a" => """a \\"quoted\\" string""")))["a"] ==
+      """a \\"quoted\\" string"""
 
 # issue 108 - dollar signs in single-line strings
 @test YAML.yaml("foo \$ bar") == "\"foo \$ bar\"\n"
@@ -429,7 +412,7 @@ order_two = OrderedDict(dict_content[[2,1]]...) # reverse order
 
 # issue 114 - gracefully handle extra commas in flow collections
 @testset "issue114" begin
-    @test YAML.load("[3,4,]") == [3,4]
+    @test YAML.load("[3,4,]") == [3, 4]
     @test YAML.load("{a:4,b:5,}") == Dict("a" => 4, "b" => 5)
     @test YAML.load("[?a:4, ?b:5]") == [Dict("a" => 4), Dict("b" => 5)]
     @test_throws YAML.ParserError YAML.load("[3,,4]")
@@ -445,8 +428,16 @@ end
 
 # issue #148 - warn unknown directives
 @testset "issue #148" begin
-    @test (@test_logs (:warn, """unknown directive name: "FOO" at line 1, column 4. We ignore this.""") YAML.load("""%FOO  bar baz\n\n--- "foo\"""")) == "foo"
-    @test (@test_logs (:warn, """unknown directive name: "FOO" at line 1, column 4. We ignore this.""") (:warn, """unknown directive name: "BAR" at line 2, column 4. We ignore this.""") YAML.load("""%FOO\n%BAR\n--- foo""")) == "foo"
+    @test (@test_logs (
+        :warn,
+        """unknown directive name: "FOO" at line 1, column 4. We ignore this.""",
+    ) YAML.load("""%FOO  bar baz\n\n--- "foo\"""")) == "foo"
+    @test (@test_logs (
+        :warn,
+        """unknown directive name: "FOO" at line 1, column 4. We ignore this.""",
+    ) (:warn, """unknown directive name: "BAR" at line 2, column 4. We ignore this.""") YAML.load(
+        """%FOO\n%BAR\n--- foo""",
+    )) == "foo"
 end
 
 end  # module


### PR DESCRIPTION
Format Julia source files by JuliaFormatter. Everyone can format sources by executing the following in the project root directory:

```julia
using JuliaFormatter

format(".")
```

Formatting styles are set in `.JuliaFormatter.toml`. If there are problems or preferences, tell me.

This solves https://github.com/JuliaData/YAML.jl/issues/154.