### PR TITLE
Remove nested includes

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -8,8 +8,14 @@ using Dates
 using Printf
 using StringEncodings
 
+include("queue.jl")
+include("buffered_input.jl")
+include("tokens.jl")
 include("scanner.jl")
+include("events.jl")
 include("parser.jl")
+include("nodes.jl")
+include("resolver.jl")
 include("composer.jl")
 include("constructor.jl")
 include("writer.jl") # write Julia dictionaries to YAML files

--- a/src/composer.jl
+++ b/src/composer.jl
@@ -1,8 +1,4 @@
 
-include("nodes.jl")
-include("resolver.jl")
-
-
 struct ComposerError
     context::Union{String, Nothing}
     context_mark::Union{Mark, Nothing}

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,6 +1,4 @@
 
-include("events.jl")
-
 const DEFAULT_TAGS = Dict{String,String}("!" => "!", "!!" => "tag:yaml.org,2002:")
 
 

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -1,27 +1,4 @@
 
-include("queue.jl")
-include("buffered_input.jl")
-
-# Position within the document being parsed
-struct Mark
-    index::UInt64
-    line::UInt64
-    column::UInt64
-end
-
-
-function show(io::IO, mark::Mark)
-    @printf(io, "line %d, column %d", mark.line, mark.column)
-end
-
-
-# Where in the stream a particular token lies.
-struct Span
-    start_mark::Mark
-    end_mark::Mark
-end
-
-
 struct SimpleKey
     token_number::UInt64
     required::Bool
@@ -43,9 +20,6 @@ function show(io::IO, error::ScannerError)
     end
     print(io, error.problem, " at ", error.problem_mark)
 end
-
-
-include("tokens.jl")
 
 
 function detect_encoding(input::IO)::Encoding

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -1,4 +1,24 @@
 
+# Position within the document being parsed
+struct Mark
+    index::UInt64
+    line::UInt64
+    column::UInt64
+end
+
+
+function show(io::IO, mark::Mark)
+    @printf(io, "line %d, column %d", mark.line, mark.column)
+end
+
+
+# Where in the stream a particular token lies.
+struct Span
+    start_mark::Mark
+    end_mark::Mark
+end
+
+
 # YAML Tokens.
 # Each token must include at minimum member "span::Span".
 abstract type Token end


### PR DESCRIPTION
Move all includes to `YAML.jl`. Also definitions of `Mark` and `Span` are moved from `src/scanner.jl` to `src/tokens.jl`. This prevents possible duplicated-includes.