### PR TITLE
Refactoring by using `isa`

### DIFF
--- a/src/composer.jl
+++ b/src/composer.jl
@@ -34,21 +34,21 @@ end
 
 function compose(events)
     composer = Composer(events, Dict{String, Node}(), Resolver())
-    @assert typeof(forward!(composer.input)) == StreamStartEvent
+    @assert forward!(composer.input) isa StreamStartEvent
     node = compose_document(composer)
-    if typeof(peek(composer.input)) == StreamEndEvent
+    if peek(composer.input) isa StreamEndEvent
         forward!(composer.input)
     else
-        @assert typeof(peek(composer.input)) == DocumentStartEvent
+        @assert peek(composer.input) isa DocumentStartEvent
     end
     node
 end
 
 
 function compose_document(composer::Composer)
-    @assert typeof(forward!(composer.input)) == DocumentStartEvent
+    @assert forward!(composer.input) isa DocumentStartEvent
     node = compose_node(composer)
-    @assert typeof(forward!(composer.input)) == DocumentEndEvent
+    @assert forward!(composer.input) isa DocumentEndEvent
     empty!(composer.anchors)
     node
 end

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -147,7 +147,7 @@ function flatten_mapping(node::MappingNode)
             elseif value_node isa SequenceNode
                 submerge = []
                 for subnode in value_node.value
-                    if typeof(subnode) != MappingNode
+                    if !(subnode isa MappingNode)
                         throw(ConstructorError("while constructing a mapping",
                                                node.start_mark,
                                                "expected a mapping node, but found $(typeof(subnode))",

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -83,7 +83,7 @@ end
 function process_directives(stream::EventStream)
     stream.yaml_version = nothing
     stream.tag_handles = Dict{String, String}()
-    while typeof(peek(stream.input)) == DirectiveToken
+    while peek(stream.input) isa DirectiveToken
         token = forward!(stream.input)
         if token.name == "YAML"
             if stream.yaml_version !== nothing
@@ -138,7 +138,7 @@ end
 function parse_implicit_document_start(stream::EventStream)
     token = peek(stream.input)
 	# Parse a byte order mark
-	if typeof(token) == ByteOrderMarkToken
+	if token isa ByteOrderMarkToken
 		forward!(stream.input)
 		token = peek(stream.input)
 	end
@@ -159,22 +159,22 @@ end
 
 function parse_document_start(stream::EventStream)
     # Parse any extra document end indicators.
-    while typeof(peek(stream.input)) == DocumentEndToken
+    while peek(stream.input) isa DocumentEndToken
         stream.input = Iterators.rest(stream.input)
     end
 
 	token = peek(stream.input)
 	# Parse a byte order mark if it exists
-	if typeof(token) == ByteOrderMarkToken
+	if token isa ByteOrderMarkToken
 		forward!(stream.input)
 		token = peek(stream.input)
 	end
 
     # Parse explicit document.
-    if typeof(token) != StreamEndToken
+    if !(token isa StreamEndToken)
         start_mark = token.span.start_mark
         version, tags = process_directives(stream)
-        if typeof(peek(stream.input)) != DocumentStartToken
+        if !(peek(stream.input) isa DocumentStartToken)
             throw(ParserError(nothing, nothing,
                 "expected '<document start>' but found $(typeof(token))"))
         end
@@ -200,7 +200,7 @@ function parse_document_end(stream::EventStream)
     token = peek(stream.input)
     start_mark = end_mark = token.span.start_mark
     explicit = false
-    if typeof(token) == DocumentEndToken
+    if token isa DocumentEndToken
         forward!(stream.input)
         end_mark = token.span.end_mark
         explicit = true
@@ -307,25 +307,25 @@ function _parse_node(token, stream::EventStream, block, indentless_sequence)
     anchor = nothing
     tag = nothing
     start_mark = end_mark = tag_mark = nothing
-    if typeof(token) == AnchorToken
+    if token isa AnchorToken
         forward!(stream.input)
         start_mark = token.span.start_mark
         end_mark = token.span.end_mark
         anchor = token.value
         token = peek(stream.input)
-        if typeof(token) == TagToken
+        if token isa TagToken
             forward!(stream.input)
             tag_mark = token.span.start_mark
             end_mark = token.span.end_mark
             tag = token.value
         end
-    elseif typeof(token) == TagToken
+    elseif token isa TagToken
         forward!(stream.input)
         start_mark = token.span.start_mark
         end_mark = token.span.end_mark
         tag = token.value
         token = peek(stream.input)
-        if typeof(token) == AnchorToken
+        if token isa AnchorToken
             forward!(stream.input)
             end_mark = token.end_mark
             anchor = token.value
@@ -353,7 +353,7 @@ function _parse_node(token, stream::EventStream, block, indentless_sequence)
 
     event = nothing
     implicit = tag === nothing || tag == "!"
-    if indentless_sequence && typeof(token) == BlockEntryToken
+    if indentless_sequence && token isa BlockEntryToken
         end_mark = token.span.end_mark
         stream.state = parse_indentless_sequence_entry
         event = SequenceStartEvent(start_mark, end_mark, anchor, tag, implicit,
@@ -379,7 +379,7 @@ end
 
 function parse_block_sequence_entry(stream::EventStream)
     token = peek(stream.input)
-    if typeof(token) == BlockEntryToken
+    if token isa BlockEntryToken
         forward!(stream.input)
         if !in(typeof(peek(stream.input)), [BlockEntryToken, BlockEndToken])
             push!(stream.states, parse_block_sequence_entry)
@@ -390,7 +390,7 @@ function parse_block_sequence_entry(stream::EventStream)
         end
     end
 
-    if typeof(token) != BlockEndToken
+    if !(token isa BlockEndToken)
         throw(ParserError("while parsing a block collection", stream.marks[end],
                           "expected <block end>, but found $(typeof(token))",
                           token.span.start_mark))
@@ -405,7 +405,7 @@ end
 
 function parse_indentless_sequence_entry(stream::EventStream)
     token = peek(stream.input)
-    if typeof(token) == BlockEntryToken
+    if token isa BlockEntryToken
         forward!(stream.input)
         if !in(typeof(peek(stream.input)), [BlockEntryToken, KeyToken, ValueToken, BlockEndToken])
             push!(stream.states, parse_indentless_sequence_entry)
@@ -430,7 +430,7 @@ end
 
 function parse_block_mapping_key(stream::EventStream)
     token = peek(stream.input)
-    if typeof(token) == KeyToken
+    if token isa KeyToken
         forward!(stream.input)
         if !in(typeof(peek(stream.input)), [KeyToken, ValueToken, BlockEndToken])
             push!(stream.states, parse_block_mapping_value)
@@ -441,7 +441,7 @@ function parse_block_mapping_key(stream::EventStream)
         end
     end
 
-    if typeof(token) != BlockEndToken
+    if !(token isa BlockEndToken)
         throw(ParserError("while parsing a block mapping", stream.marks[end],
                           "expected <block end>, but found $(typeof(token))",
                           token.span.start_mark))
@@ -456,7 +456,7 @@ end
 
 function parse_block_mapping_value(stream::EventStream)
     token = peek(stream.input)
-    if typeof(token) == ValueToken
+    if token isa ValueToken
         forward!(stream.input)
         if !in(typeof(peek(stream.input)), [KeyToken, ValueToken, BlockEndToken])
             push!(stream.states, parse_block_mapping_key)
@@ -487,7 +487,7 @@ end
 
 function _parse_flow_sequence_entry(token::Any, stream::EventStream, first_entry=false)
     if !first_entry
-        if typeof(token) == FlowEntryToken
+        if token isa FlowEntryToken
             forward!(stream.input)
         else
             throw(ParserError("while parsing a flow sequence",
@@ -529,7 +529,7 @@ end
 
 function parse_flow_sequence_entry_mapping_value(stream::EventStream)
     token = peek(stream.input)
-    if typeof(token) == ValueToken
+    if token isa ValueToken
         forward!(stream.input)
         if !in(typeof(peek(stream.input)), [FlowEntryToken, FlowSequenceEndToken])
             push!(stream.states, parse_flow_sequence_entry_mapping_end)
@@ -561,9 +561,9 @@ end
 
 function parse_flow_mapping_key(stream::EventStream, first_entry=false)
     token = peek(stream.input)
-    if typeof(token) != FlowMappingEndToken
+    if !(token isa FlowMappingEndToken)
         if !first_entry
-            if typeof(token) == FlowEntryToken
+            if token isa FlowEntryToken
                 forward!(stream.input)
             else
                 throw(ParserError("while parsing a flow mapping",
@@ -574,7 +574,7 @@ function parse_flow_mapping_key(stream::EventStream, first_entry=false)
         end
 
         token = peek(stream.input)
-        if typeof(token) == KeyToken
+        if token isa KeyToken
             forward!(stream.input)
             if !in(typeof(peek(stream.input)), [ValueToken, FlowEntryToken, FlowMappingEndToken])
                 push!(stream.states, parse_flow_mapping_value)
@@ -583,7 +583,7 @@ function parse_flow_mapping_key(stream::EventStream, first_entry=false)
                 stream.state = parse_flow_mapping_value
                 return process_empty_scalar(stream, token.span.end_mark)
             end
-        elseif typeof(token) != FlowMappingEndToken
+        elseif !(token isa FlowMappingEndToken)
             push!(stream.states, parse_flow_mapping_empty_value)
             return parse_flow_node(stream)
         end
@@ -598,7 +598,7 @@ end
 
 function parse_flow_mapping_value(stream::EventStream)
     token = peek(stream.input)
-    if typeof(token) == ValueToken
+    if token isa ValueToken
         forward!(stream.input)
         if !in(typeof(peek(stream.input)), [FlowEntryToken, FlowMappingEndToken])
             push!(stream.states, parse_flow_mapping_key)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -142,7 +142,7 @@ function parse_implicit_document_start(stream::EventStream)
 		forward!(stream.input)
 		token = peek(stream.input)
 	end
-    if !in(typeof(token), [DirectiveToken, DocumentStartToken, StreamEndToken])
+    if !(token isa Union{DirectiveToken, DocumentStartToken, StreamEndToken})
         stream.tag_handles = DEFAULT_TAGS
         event = DocumentStartEvent(token.span.start_mark, token.span.start_mark,
                                    false)
@@ -381,7 +381,7 @@ function parse_block_sequence_entry(stream::EventStream)
     token = peek(stream.input)
     if token isa BlockEntryToken
         forward!(stream.input)
-        if !in(typeof(peek(stream.input)), [BlockEntryToken, BlockEndToken])
+        if !(peek(stream.input) isa Union{BlockEntryToken, BlockEndToken})
             push!(stream.states, parse_block_sequence_entry)
             return parse_block_node(stream)
         else
@@ -407,7 +407,7 @@ function parse_indentless_sequence_entry(stream::EventStream)
     token = peek(stream.input)
     if token isa BlockEntryToken
         forward!(stream.input)
-        if !in(typeof(peek(stream.input)), [BlockEntryToken, KeyToken, ValueToken, BlockEndToken])
+        if !(peek(stream.input) isa Union{BlockEntryToken, KeyToken, ValueToken, BlockEndToken})
             push!(stream.states, parse_indentless_sequence_entry)
             return parse_block_node(stream)
         else
@@ -432,7 +432,7 @@ function parse_block_mapping_key(stream::EventStream)
     token = peek(stream.input)
     if token isa KeyToken
         forward!(stream.input)
-        if !in(typeof(peek(stream.input)), [KeyToken, ValueToken, BlockEndToken])
+        if !(peek(stream.input) isa Union{KeyToken, ValueToken, BlockEndToken})
             push!(stream.states, parse_block_mapping_value)
             return parse_block_node_or_indentless_sequence(stream)
         else
@@ -458,7 +458,7 @@ function parse_block_mapping_value(stream::EventStream)
     token = peek(stream.input)
     if token isa ValueToken
         forward!(stream.input)
-        if !in(typeof(peek(stream.input)), [KeyToken, ValueToken, BlockEndToken])
+        if !(peek(stream.input) isa Union{KeyToken, ValueToken, BlockEndToken})
             push!(stream.states, parse_block_mapping_key)
             parse_block_node_or_indentless_sequence(stream)
         else
@@ -517,7 +517,7 @@ end
 
 function parse_flow_sequence_entry_mapping_key(stream::EventStream)
     token = forward!(stream.input)
-    if !in(typeof(token), [ValueToken, FlowEntryToken, FlowSequenceEndToken])
+    if !(token isa Union{ValueToken, FlowEntryToken, FlowSequenceEndToken})
         push!(stream.states, parse_flow_sequence_entry_mapping_value)
         parse_flow_node(stream)
     else
@@ -531,7 +531,7 @@ function parse_flow_sequence_entry_mapping_value(stream::EventStream)
     token = peek(stream.input)
     if token isa ValueToken
         forward!(stream.input)
-        if !in(typeof(peek(stream.input)), [FlowEntryToken, FlowSequenceEndToken])
+        if !(peek(stream.input) isa Union{FlowEntryToken, FlowSequenceEndToken})
             push!(stream.states, parse_flow_sequence_entry_mapping_end)
             parse_flow_node(stream)
         else
@@ -576,7 +576,7 @@ function parse_flow_mapping_key(stream::EventStream, first_entry=false)
         token = peek(stream.input)
         if token isa KeyToken
             forward!(stream.input)
-            if !in(typeof(peek(stream.input)), [ValueToken, FlowEntryToken, FlowMappingEndToken])
+            if !(peek(stream.input) isa Union{ValueToken, FlowEntryToken, FlowMappingEndToken})
                 push!(stream.states, parse_flow_mapping_value)
                 return parse_flow_node(stream)
             else
@@ -600,7 +600,7 @@ function parse_flow_mapping_value(stream::EventStream)
     token = peek(stream.input)
     if token isa ValueToken
         forward!(stream.input)
-        if !in(typeof(peek(stream.input)), [FlowEntryToken, FlowMappingEndToken])
+        if !(peek(stream.input) isa Union{FlowEntryToken, FlowMappingEndToken})
             push!(stream.states, parse_flow_mapping_key)
             parse_flow_node(stream)
         else


### PR DESCRIPTION
Change direct comparisons of types `typeof(x) == ConcreteType` to using `x isa ConcreteType`. Especially, `isa(x, Union{A, B, C})` is better than `in(typeof(x), [A, B, C])` in terms of performance.