### PR TITLE
Fix a bug in `parse_document_content`.

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -214,7 +214,7 @@ end
 
 
 function parse_document_content(stream::EventStream)
-    if in(peek(stream.input), [DirectiveToken, DocumentStartToken, DocumentEndToken,StreamEndToken])
+    if peek(stream.input) isa Union{DirectiveToken, DocumentStartToken, DocumentEndToken,StreamEndToken}
         event = process_empty_scalar(stream, peek(stream.input).span.start_mark)
         stream.state = pop!(stream.states)
         event

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -214,7 +214,7 @@ end
 
 
 function parse_document_content(stream::EventStream)
-    if peek(stream.input) isa Union{DirectiveToken, DocumentStartToken, DocumentEndToken,StreamEndToken}
+    if peek(stream.input) isa Union{DirectiveToken, DocumentStartToken, DocumentEndToken, StreamEndToken}
         event = process_empty_scalar(stream, peek(stream.input).span.start_mark)
         stream.state = pop!(stream.states)
         event

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -449,4 +449,9 @@ end
     @test (@test_logs (:warn, """unknown directive name: "FOO" at line 1, column 4. We ignore this.""") (:warn, """unknown directive name: "BAR" at line 2, column 4. We ignore this.""") YAML.load("""%FOO\n%BAR\n--- foo""")) == "foo"
 end
 
+# issue #144
+@testset "issue #144" begin
+    @test YAML.load("---") === nothing
+end
+
 end  # module


### PR DESCRIPTION
`peek(stream.input)` is a token instance, so it should be `in(typeof(peek(stream.input)), [A, B, C, D]`. However, it is better to use `isa` and `Union`, as I mentioned in https://github.com/JuliaData/YAML.jl/pull/161. So I fix to it.