### PR TITLE
Fix a bug of `scan_uri_escapes`

### DIFF
--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -1577,7 +1577,7 @@ function scan_uri_escapes(stream::TokenStream, name::String, start_mark::Mark)
                                    get_mark(stream)))
             end
         end
-        push!(bytes, char(parse_hex(prefix(stream.input, 2))))
+        push!(bytes, Char(parse(Int, prefix(stream.input, 2), base=16)))
         forwardchars!(stream, 2)
     end
 


### PR DESCRIPTION
Change deprecated functions to new ones. Solves https://github.com/JuliaData/YAML.jl/issues/164.