### PR TITLE
Remove a bit misleading comment and change the expression.

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -37,7 +37,7 @@ include("nodes.jl")
 include("resolver.jl")
 include("composer.jl")
 include("constructor.jl")
-include("writer.jl") # write Julia dictionaries to YAML files
+include("writer.jl")
 
 const _constructor = Union{Nothing, Dict}
 const _dicttype = Union{Type,Function}

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -1,5 +1,5 @@
 #
-# Writing Julia dictionaries to YAML files is implemented with multiple dispatch and recursion:
+# Writing Julia collections to YAML files is implemented with multiple dispatch and recursion:
 # Depending on the value type, Julia chooses the appropriate _print function, which may add a
 # level of recursion.
 #


### PR DESCRIPTION
Writers can process not only dictionaries.