### PR TITLE
[Bug Fix] Fix a bug that `isnumeric` is misused

### DIFF
--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -840,7 +840,7 @@ end
 function scan_directive_name(stream::TokenStream, start_mark::Mark)
     length = 0
     c = peek(stream.input)
-    while isletter(c) || isnumeric(c) || c == '-' || c == '_'
+    while isletter(c) || isdigit(c) || c == '-' || c == '_'
         length += 1
         c = peek(stream.input, length)
     end
@@ -963,7 +963,7 @@ function scan_anchor(stream::TokenStream, tokentype)
     forwardchars!(stream)
     length = 0
     c = peek(stream.input)
-    while isletter(c) || isnumeric(c) || c == '-' || c == '_'
+    while isletter(c) || isdigit(c) || c == '-' || c == '_'
         length += 1
         c = peek(stream.input, length)
     end
@@ -1485,7 +1485,7 @@ function scan_tag_handle(stream::TokenStream, name::String, start_mark::Mark)
     length = 1
     c = peek(stream.input, length)
     if c != ' '
-        while isletter(c) || isnumeric(c) || c == '-' || c == '_'
+        while isletter(c) || isdigit(c) || c == '-' || c == '_'
             length += 1
             c = peek(stream.input, length)
         end
@@ -1509,7 +1509,7 @@ function scan_tag_uri(stream::TokenStream, name::String, start_mark::Mark)
     chunks = Any[]
     length = 0
     c = peek(stream.input, length)
-    while isletter(c) || isnumeric(c) || in(c, "-;/?:@&=+\$,_.!~*\'()[]%")
+    while isletter(c) || isdigit(c) || in(c, "-;/?:@&=+\$,_.!~*\'()[]%")
         if c == '%'
             push!(chunks, prefix(stream.input, length))
             forwardchars!(stream, length)


### PR DESCRIPTION
Replace misused `isnumeric` to `isdigit`. `isnumeric` returns `true` for any numeric characters:

```julia-repl
julia> isnumeric('⁴')
true
```