### PR TITLE
[Performance, No Breaking] Add YAML 1.1 `b-char` function.

### DIFF
--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -1,3 +1,5 @@
+# [27] b-char ::= b-line-feed | b-carriage-return | b-next-line | b-line-separator | b-paragraph-separator
+yaml_1_1_is_b_char(c::Char) = c == '\n' || c == '\r' || c == '\u85' || c == '\u2028' || c == '\u2029'
 
 struct SimpleKey
     token_number::UInt64
@@ -1187,7 +1189,7 @@ function scan_block_scalar_breaks(stream::TokenStream, indent)
         forwardchars!(stream)
     end
 
-    while in(peek(stream.input), "\r\n\u0085\u2028\u2029")
+    while yaml_1_1_is_b_char(peek(stream.input))
         push!(chunks, scan_line_break(stream))
         end_mark = get_mark(stream)
         while stream.column < indent && peek(stream.input) == ' '
@@ -1287,7 +1289,7 @@ function scan_flow_scalar_non_spaces(stream::TokenStream, double::Bool,
                 end
                 push!(chunks, Char(parse(Int, prefix(stream.input, length), base = 16)))
                 forwardchars!(stream, length)
-            elseif in(c, "\r\n\u0085\u2028\u2029")
+            elseif yaml_1_1_is_b_char(c)
                 scan_line_break(stream)
                 append!(chunks, scan_flow_scalar_breaks(stream, double, start_mark))
             else
@@ -1317,7 +1319,7 @@ function scan_flow_scalar_spaces(stream::TokenStream, double::Bool,
     if c == '\0'
         throw(ScannerError("while scanning a quoted scalar", start_mark,
                            "found unexpected end of stream", get_mark(stream)))
-    elseif in(c, "\r\n\u0085\u2028\u2029")
+    elseif yaml_1_1_is_b_char(c)
         line_break = scan_line_break(stream)
         breaks = scan_flow_scalar_breaks(stream, double, start_mark)
         if line_break != '\n'
@@ -1350,7 +1352,7 @@ function scan_flow_scalar_breaks(stream::TokenStream, double::Bool,
             forward!(stream.input)
         end
 
-        if in(peek(stream.input), "\r\n\u0085\u2028\u2029")
+        if yaml_1_1_is_b_char(peek(stream.input))
             push!(chunks, scan_line_break(stream))
         else
             return chunks
@@ -1434,7 +1436,7 @@ function scan_plain_spaces(stream::TokenStream, indent::Integer,
     whitespaces = prefix(stream.input, length)
     forwardchars!(stream, length)
     c = peek(stream.input)
-    if in(c, "\r\n\u0085\u2028\u2029")
+    if yaml_1_1_is_b_char(c)
         line_break = scan_line_break(stream)
         stream.allow_simple_key = true
         if peek(stream.input) == '\uFEFF'


### PR DESCRIPTION
Add YAML 1.1 [27] `b-char` function `yaml_1_1_is_b_char` and use it. It is better in performance and explicit that uses YAML 1.1 function.