### PR TITLE
Change `forwardchars!` to return nothing.

### DIFF
--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -150,6 +150,7 @@ function forwardchars!(stream::TokenStream, k::Integer)
         end
     end
     stream.index += k
+    nothing
 end
 
 forwardchars!(stream::TokenStream) = forwardchars!(stream, 1)


### PR DESCRIPTION
Currently, `forwardchars!` returns meaningless index. Change to explicitly return `nothing`.