### PR TITLE
[Performance, No Breaking] Use `yaml_1_1_is_whitespace` more.

### DIFF
--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -352,7 +352,7 @@ end
 # Checkers
 # --------
 
-const whitespace = "\0 \t\r\n\u0085\u2028\u2029"
+yaml_1_1_is_whitespace(c::Char) = c == '\0' || c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\u85' || c == '\u2028' || c == '\u2029'
 
 
 function check_directive(stream::TokenStream)
@@ -362,31 +362,31 @@ end
 function check_document_start(stream::TokenStream)
     stream.column == 0 &&
         prefix(stream.input, 3) == "---" &&
-        in(peek(stream.input, 3), whitespace)
+        yaml_1_1_is_whitespace(peek(stream.input, 3))
 end
 
  function check_document_end(stream::TokenStream)
      stream.column == 0 &&
      prefix(stream.input, 3) == "..." &&
-    (in(peek(stream.input, 3), whitespace) || peek(stream.input, 3) === nothing)
+    (yaml_1_1_is_whitespace(peek(stream.input, 3)) || peek(stream.input, 3) === nothing)
  end
 
 function check_block_entry(stream::TokenStream)
-    in(peek(stream.input, 1), whitespace)
+    yaml_1_1_is_whitespace(peek(stream.input, 1))
 end
 
 function check_key(stream::TokenStream)
-    stream.flow_level > 0 || in(peek(stream.input, 1), whitespace)
+    stream.flow_level > 0 || yaml_1_1_is_whitespace(peek(stream.input, 1))
 end
 
 function check_value(stream::TokenStream)
     cnext = peek(stream.input, 1)
-    stream.flow_level > 0 || in(cnext, whitespace) || cnext === nothing
+    stream.flow_level > 0 || yaml_1_1_is_whitespace(cnext) || cnext === nothing
 end
 
 function check_plain(stream::TokenStream)
     !in(peek(stream.input), "\0 \t\r\n\u0085\u2028\u2029-?:,[]{}#&*!|>\'\"%@`\uFEFF") ||
-    (!in(peek(stream.input, 1), whitespace) &&
+    (!yaml_1_1_is_whitespace(peek(stream.input, 1)) &&
      (peek(stream.input) == '-' || (stream.flow_level == 0 &&
                               in(peek(stream.input), "?:"))))
 end
@@ -1411,10 +1411,10 @@ function scan_plain(stream::TokenStream)
         while true
             c = peek(stream.input, length)
             cnext = peek(stream.input, length + 1)
-            if in(c, whitespace) ||
+            if yaml_1_1_is_whitespace(c) ||
                 c === nothing ||
                 (stream.flow_level == 0 && c == ':' &&
-                    (cnext === nothing || in(cnext, whitespace))) ||
+                    (cnext === nothing || yaml_1_1_is_whitespace(cnext))) ||
                 (stream.flow_level != 0 && in(c, ",:?[]{}"))
                 break
             end

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -1002,9 +1002,10 @@ function scan_anchor(stream::TokenStream, ::Type{T}) where {T<:Token}
     end
     value = prefix(stream.input, length)
     forwardchars!(stream, length)
-    if !in(peek(stream.input), "\0 \t\r\n\u0085\u2028\u2029?:,]}%@`")
+    c = peek(stream.input)
+    if !(yaml_1_1_is_whitespace(c) || in(c, "?:,]}%@`"))
         throw(ScannerError("while scanning an $(name)", start_mark,
-                           "expected an alphanumeric character, but found '$(peek(stream.input))'",
+                           "expected an alphanumeric character, but found '$c'",
                            get_mark(stream)))
     end
     end_mark = get_mark(stream)
@@ -1025,7 +1026,7 @@ function scan_tag(stream::TokenStream)
                                get_mark(stream)))
         end
         forwardchars!(stream)
-    elseif in(c, "\0 \t\r\n\u0085\u2028\u2029")
+    elseif yaml_1_1_is_whitespace(c)
         handle = nothing
         suffix = '!'
         forwardchars!(stream)
@@ -1277,8 +1278,10 @@ function scan_flow_scalar_non_spaces(stream::TokenStream, double::Bool,
     chunks = Any[]
     while true
         length = 0
-        while !in(peek(stream.input, length), "\'\"\\\0 \t\r\n\u0085\u2028\u2029")
+        c = peek(stream.input, length)
+        while !(in(c, "\'\"\\") || yaml_1_1_is_whitespace(c))
             length += 1
+            c = peek(stream.input, length)
         end
         if length > 0
             push!(chunks, prefix(stream.input, length))
@@ -1366,8 +1369,7 @@ function scan_flow_scalar_breaks(stream::TokenStream, double::Bool,
     chunks = Any[]
     while true
         pref = prefix(stream.input, 3)
-        if pref == "---" || pref == "..." &&
-           in(peek(stream.input, 3), "\0 \t\r\n\u0085\u2028\u2029")
+        if pref == "---" || pref == "..." && yaml_1_1_is_whitespace(peek(stream.input, 3))
             throw(ScannerError("while scanning a quoted scalar", start_mark,
                                "found unexpected document seperator",
                                get_mark(stream)))
@@ -1423,8 +1425,10 @@ function scan_plain(stream::TokenStream)
 
         # It's not clear what we should do with ':' in the flow context.
         c = peek(stream.input)
-        if stream.flow_level != 0 && c == ':' &&
-            !in(peek(stream.input, length + 1), "\0 \t\r\n\u0085\u2028\u2029,[]{}")
+        if stream.flow_level != 0 && c == ':' && begin
+                cnext = peek(stream.input, length + 1)
+                !(yaml_1_1_is_whitespace(cnext) || in(cnext, ",[]{}"))
+            end
             forwardchars!(stream, length)
             throw(ScannerError("while scanning a plain scalar", start_mark,
                                "found unexpected ':'", get_mark(stream)))
@@ -1468,8 +1472,7 @@ function scan_plain_spaces(stream::TokenStream, indent::Integer,
             return Any[]
         end
         pref = prefix(stream.input, 3)
-        if pref == "---" || pref == "..." &&
-            in(peek(stream.input, 3), "\0 \t\r\n\u0085\u2028\u2029")
+        if pref == "---" || pref == "..." && yaml_1_1_is_whitespace(peek(stream.input, 3))
             return Any[]
         end
 
@@ -1483,8 +1486,7 @@ function scan_plain_spaces(stream::TokenStream, indent::Integer,
                     return Any[]
                 end
                 pref = prefix(stream.input, 3)
-                if pref == "---" || pref == "..." &&
-                    in(peek(stream.input, 3), "\0 \t\r\n\u0085\u2028\u2029")
+                if pref == "---" || pref == "..." && yaml_1_1_is_whitespace(peek(stream.input, 3))
                     return Any[]
                 end
             end


### PR DESCRIPTION
This depends on #200. Use `yaml_1_1_is_whitespace` more.