### PR TITLE
Make YAMLDocIterator collectable

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -100,6 +100,11 @@ end
 
 YAMLDocIterator(input::IO, more_constructors::_constructor=nothing, multi_constructors::Dict = Dict(); dicttype::_dicttype=Dict{Any, Any}, constructorType::Function = SafeConstructor) = YAMLDocIterator(input, constructorType(_patch_constructors(more_constructors, dicttype), multi_constructors))
 
+# It's unknown how many documents will be found. By doing this,
+# functions like `collect` do not try to query the length of the
+# iterator.
+Base.IteratorSize(::YAMLDocIterator) = Base.SizeUnknown()
+
 # Old iteration protocol:
 start(it::YAMLDocIterator) = nothing
 


### PR DESCRIPTION
Let me do something more active than reviewing for a change. This PR sets the iterator size of `YAMLDocIterator` to unknown, so you can do
```
julia> collect(YAML.load_all("1\n...\n2"))
2-element Vector{Any}:
 1
 2
```
instead of getting
```
julia> collect(YAML.load_all("1\n...\n2"))
ERROR: MethodError: no method matching length(::YAML.YAMLDocIterator)
```
(Hopefully @Paalon hasn't already done this in a PR I haven't found yet.)
