### PR TITLE
Gracefully handle no document files/streams

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -100,6 +100,11 @@ end
 
 YAMLDocIterator(input::IO, more_constructors::_constructor=nothing, multi_constructors::Dict = Dict(); dicttype::_dicttype=Dict{Any, Any}, constructorType::Function = SafeConstructor) = YAMLDocIterator(input, constructorType(_patch_constructors(more_constructors, dicttype), multi_constructors))
 
+# It's unknown how many documents will be found. By doing this,
+# functions like `collect` do not try to query the length of the
+# iterator.
+Base.IteratorSize(::YAMLDocIterator) = Base.SizeUnknown()
+
 # Old iteration protocol:
 start(it::YAMLDocIterator) = nothing
 

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -105,10 +105,9 @@ YAMLDocIterator(input::IO, more_constructors::_constructor=nothing, multi_constr
 # iterator.
 Base.IteratorSize(::YAMLDocIterator) = Base.SizeUnknown()
 
-# Old iteration protocol:
-start(it::YAMLDocIterator) = nothing
-
-function next(it::YAMLDocIterator, state)
+# Iteration protocol.
+function iterate(it::YAMLDocIterator, _ = nothing)
+    it.next_doc === nothing && return nothing
     doc = it.next_doc
     if eof(it.input)
         it.next_doc = nothing
@@ -118,12 +117,6 @@ function next(it::YAMLDocIterator, state)
     end
     return doc, nothing
 end
-
-done(it::YAMLDocIterator, state) = it.next_doc === nothing
-
-# 0.7 iteration protocol:
-iterate(it::YAMLDocIterator) = next(it, start(it))
-iterate(it::YAMLDocIterator, s) = done(it, s) ? nothing : next(it, s)
 
 """
     load_all(x::Union{AbstractString, IO}) -> YAMLDocIterator

--- a/src/composer.jl
+++ b/src/composer.jl
@@ -41,6 +41,7 @@ end
 
 
 function compose_document(composer::Composer)
+    peek(composer.input) isa StreamEndEvent && return nothing
     @assert forward!(composer.input) isa DocumentStartEvent
     node = compose_node(composer)
     @assert forward!(composer.input) isa DocumentEndEvent

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -56,6 +56,7 @@ function construct_document(constructor::Constructor, node::Node)
     data
 end
 
+construct_document(::Constructor, ::Nothing) = nothing
 
 function construct_object(constructor::Constructor, node::Node)
     if haskey(constructor.constructed_objects, node)


### PR DESCRIPTION
Return `nothing` when `load` fails to find any content instead of failing an assertion.

This also does away with the remnants of the pre Julia 0.7 iteration protocol and fixes an iteration bug when the iterator is empty.

Fixes #102, #129, #132, #143.

First commit is #215.
