### PR TITLE
Fix load_all of null documents

### DIFF
--- a/src/composer.jl
+++ b/src/composer.jl
@@ -41,7 +41,7 @@ end
 
 
 function compose_document(composer::Composer)
-    peek(composer.input) isa StreamEndEvent && return nothing
+    peek(composer.input) isa StreamEndEvent && return missing_document
     @assert forward!(composer.input) isa DocumentStartEvent
     node = compose_node(composer)
     @assert forward!(composer.input) isa DocumentEndEvent

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -56,7 +56,7 @@ function construct_document(constructor::Constructor, node::Node)
     data
 end
 
-construct_document(::Constructor, ::Nothing) = nothing
+construct_document(::Constructor, ::MissingDocument) = missing_document
 
 function construct_object(constructor::Constructor, node::Node)
     if haskey(constructor.constructed_objects, node)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -450,4 +450,19 @@ end
     # end
 end
 
+# issue #226 - loadall stops on a null document
+@testset "issue #226" begin
+    @test collect(YAML.load_all("null")) == [nothing]
+    input = """
+            ---
+            1
+            ---
+            null
+            ---
+            2
+            """
+    expected = [1, nothing, 2]
+    @test collect(YAML.load_all(input)) == expected
+end
+
 end  # module


### PR DESCRIPTION
Fixes #226 by internally representing non-documents (e.g. whitespace and comments only) by ~`missing`. (This could have used~ a strictly internal singleton struct ~, but `missing` seemed reasonably fitting for the purpose.)~.