### PR TITLE
Allow duplicate keys when merge tags are used.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest
+          - macOS-13
         arch:
           - x64
           - x86
         exclude:
-          - os: macOS-latest
+          - os: macOS-13
             arch: x86
     steps:
       - uses: actions/checkout@v4
@@ -33,18 +33,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
           - os: macOS-latest
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: julia-actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "YAML"
 uuid = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-version = "0.4.13"
+version = "0.4.14"
 
 
 [deps]


### PR DESCRIPTION
Do not complain about duplicated keys when using the YAML merge tag, cf. https://github.com/JuliaData/YAML.jl/pull/141#issuecomment-2898345909.

For an example, this PR makes
```
julia> YAML.load("""
       a: &A
         x: 1
         y: 2
       b:
         <<: *A
         y: 3
       """)
┌ Error: Duplicate key detected in mapping
│   node = YAML.MappingNode("tag:yaml.org,2002:map", Any[(YAML.ScalarNode("tag:yaml.org,2002:str", "x", line 2, column 2, line 2, column 3, nothing), YAML.ScalarNode("tag:yaml.org,2002:int", "1", line 2, column 5, line 2, column 6, nothing)), (YAML.ScalarNode("tag:yaml.org,2002:str", "y", line 3, column 2, line 3, column 3, nothing), YAML.ScalarNode("tag:yaml.org,2002:int", "2", line 3, column 5, line 3, column 6, nothing)), (YAML.ScalarNode("tag:yaml.org,2002:str", "y", line 6, column 2, line 6, column 3, nothing), YAML.ScalarNode("tag:yaml.org,2002:int", "3", line 6, column 5, line 6, column 6, nothing))], line 5, column 2, line 7, column 0, false)
│   key = "y"
└ @ YAML ~/.julia/dev/YAML/src/constructor.jl:195
Dict{Any, Any} with 2 entries:
  "b" => Dict{Any, Any}("x"=>1, "y"=>3)
  "a" => Dict{Any, Any}("x"=>1, "y"=>2)
```
work without any `@error` message.